### PR TITLE
Refer to a specify UI5 version in fiori.html.

### DIFF
--- a/app/fiori.html
+++ b/app/fiori.html
@@ -39,8 +39,8 @@
 		};
 	</script>
 
-	<script src="https://sapui5.hana.ondemand.com/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
-	<script src="https://sapui5.hana.ondemand.com/resources/sap-ui-core.js"
+	<script src="https://sapui5.hana.ondemand.com/1.79.2/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
+	<script src="https://sapui5.hana.ondemand.com/1.79.2/resources/sap-ui-core.js"
     	data-sap-ui-libs="sap.m, sap.ushell, sap.collaboration, sap.ui.layout"
     	data-sap-ui-compatVersion="edge"
     	data-sap-ui-theme="sap_fiori_3"


### PR DESCRIPTION
- without a specific UI5 version this error occurs:

App kann nicht geöffnet werden, weil die SAP-UI5-Komponente der
Anwendung nicht geladen werden konnte.
UI5-Komponente für Navigationsabsicht "#browse-books" wurde nicht
geladen.

- Found this root cause in browser console:

Access to XMLHttpRequest at 'https://sapui5.hana.ondemand.com/resources/sap/fe/core/converters/controls/PresentationConverter.js' from origin 'http://localhost:8080' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

- see https://ui5.sap.com/versionoverview.html to get an overview about all UI5 releases