### PR TITLE
make spring beans and their constructors package private

### DIFF
--- a/srv/src/main/java/my/bookshop/handlers/AdminServiceHandler.java
+++ b/srv/src/main/java/my/bookshop/handlers/AdminServiceHandler.java
@@ -49,7 +49,7 @@ import my.bookshop.MessageKeys;
  */
 @Component
 @ServiceName(AdminService_.CDS_NAME)
-public class AdminServiceHandler implements EventHandler {
+class AdminServiceHandler implements EventHandler {
 
 	private final DraftService adminService;
 
@@ -59,7 +59,7 @@ public class AdminServiceHandler implements EventHandler {
 
 	private final CqnAnalyzer analyzer;
 
-	public AdminServiceHandler(@Qualifier(AdminService_.CDS_NAME) DraftService adminService, PersistenceService db, Messages messages, CdsModel model) {
+	AdminServiceHandler(@Qualifier(AdminService_.CDS_NAME) DraftService adminService, PersistenceService db, Messages messages, CdsModel model) {
 		this.adminService = adminService;
 		this.db = db;
 		this.messages = messages;

--- a/srv/src/main/java/my/bookshop/handlers/CatalogServiceHandler.java
+++ b/srv/src/main/java/my/bookshop/handlers/CatalogServiceHandler.java
@@ -24,11 +24,11 @@ import cds.gen.catalogservice.CatalogService_;
  */
 @Component
 @ServiceName(CatalogService_.CDS_NAME)
-public class CatalogServiceHandler implements EventHandler {
+class CatalogServiceHandler implements EventHandler {
 
 	private final PersistenceService db;
 
-	public CatalogServiceHandler(PersistenceService db) {
+	CatalogServiceHandler(PersistenceService db) {
 		this.db = db;
 	}
 

--- a/srv/src/main/java/my/bookshop/handlers/SubscriptionHandler.java
+++ b/srv/src/main/java/my/bookshop/handlers/SubscriptionHandler.java
@@ -14,7 +14,7 @@ import com.sap.cds.services.mt.MtUnsubscribeEventContext;
 @Component
 @Profile("cloud")
 @ServiceName(MtSubscriptionService.DEFAULT_NAME)
-public class SubscriptionHandler implements EventHandler {
+class SubscriptionHandler implements EventHandler {
 
 	@Before(event = MtSubscriptionService.EVENT_UNSUBSCRIBE)
 	public void beforeUnsubscribe(MtUnsubscribeEventContext context) {


### PR DESCRIPTION
the classes and constructors of spring beans don't
need to be public but can be package private. by this
manual construction and thereby circumventing dependency
injection is prevented. Unit tests need to reside in the same
package, though. But this is considered best practice anyhow.