### PR TITLE
Fix warnings and errors from annotation modeler

### DIFF
--- a/app/browse/fiori-service.cds
+++ b/app/browse/fiori-service.cds
@@ -11,6 +11,9 @@ using CatalogService from '../../srv/cat-service';
 annotate CatalogService.Books with @(
 	UI: {
 		HeaderInfo: {
+			TypeName: '{i18n>Book}',
+			TypeNamePlural: '{i18n>Books}',
+			Title: {Value: title},
 			Description: {Value: author}
 		},
 		HeaderFacets: [

--- a/srv/admin-service.cds
+++ b/srv/admin-service.cds
@@ -17,7 +17,7 @@ annotate AdminService.Books with @cds.search : {descr, title};
 
 // Enable Fiori Draft for Orders
 annotate AdminService.Orders with @odata.draft.enabled;
-annotate AdminService.Books with @odata.draft.enabled @Capabilities.Insertable: false;
+annotate AdminService.Books with @odata.draft.enabled @Capabilities.InsertRestrictions.Insertable: false;
 
 // workaround to enable the value help for languages
 // Necessary because auto exposure is currently not working


### PR DESCRIPTION
The CDS VS Code Plugin now brings an annotation modeler and validator.
This change fixes some warnings and errors that it reported:
- @Capabilities.Insertable: false is not correct according to the OData Vocabularies
- The UI.HeaderInfo annotation was missing some mandatory fields