### PR TITLE
Make handler work with draft GC

### DIFF
--- a/srv/src/main/java/my/bookshop/handlers/AdminServiceHandler.java
+++ b/srv/src/main/java/my/bookshop/handlers/AdminServiceHandler.java
@@ -149,7 +149,9 @@ class AdminServiceHandler implements EventHandler {
 	@Before(event = DraftService.EVENT_DRAFT_CANCEL, entity = OrderItems_.CDS_NAME)
 	public void cancelOrderItems(DraftCancelEventContext context) {
 		String orderItemId = (String) analyzer.analyze(context.getCqn()).targetKeys().get(OrderItems.ID);
-		calculateNetAmountInDraft(orderItemId, 0, null);
+		if(orderItemId != null) {
+			calculateNetAmountInDraft(orderItemId, 0, null);
+		}
 	}
 
 	private BigDecimal calculateNetAmountInDraft(String orderItemId, Integer newAmount, String newBookId) {


### PR DESCRIPTION
During a draft GC all drafts older than a specific time are deleted.
It is therefore not possible to recalculate elements for a specific draft and no draft ID can be obtained from the CQN.
We just skip our custom before handler in that case, which is anyway mainly useful in UI scenarios.