### PR TITLE
Remove deprecated cds build command from pom.xml

### DIFF
--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -117,7 +117,7 @@
 						</goals>
 						<configuration>
 							<commands>
-								<command>build/all --clean</command>
+								<command>build</command>
 
 								<command>deploy --to sqlite --dry >
 									${project.basedir}/src/main/resources/schema.sql</command>


### PR DESCRIPTION
According the `cds build --help` output, the argument --clean is deprecated:

```
    -c | --clean deprecated

        Incremental builds are not supported.
        Build output folders are always cleaned before build.
```