### PR TITLE
Fix syntax of side-effects

### DIFF
--- a/app/orders/fiori-service.cds
+++ b/app/orders/fiori-service.cds
@@ -82,21 +82,20 @@ annotate AdminService.Orders with @(
 		},
 	},
 	Common: {
-		SideEffects#AmountChanges: {
+		SideEffects#ItemsChanges: {
 			SourceEntities: [
 				Items
 			],
 			TargetProperties: [
-				total
+				'total'
 			]
 		},
 		SideEffects#CurrencyChanges: {
 			SourceProperties: [
 				currency_code
 			],
-			TargetProperties: [
-				currency.code,
-				total
+			TargetEntities: [
+				currency
 			]
 		}
 	}
@@ -152,15 +151,18 @@ annotate AdminService.OrderItems with @(
 				amount
 			],
 			TargetProperties: [
-				netAmount, parent.total
+				'netAmount'
 			]
 		},
 		SideEffects#BookChanges: {
 			SourceProperties: [
 				book_ID
 			],
+			TargetEntities: [
+				book
+			],
 			TargetProperties: [
-				netAmount, book.price, parent.total
+				'netAmount'
 			]
 		}
 	}


### PR DESCRIPTION
TargetProperties need to be passed as String values.
TargetEntities need to be used instead of using paths in TargetProperties.