### PR TITLE
Fix cds build on cf and non dev environment

### DIFF
--- a/db/package.json
+++ b/db/package.json
@@ -1,11 +1,9 @@
 {
   "name": "deploy",
   "dependencies": {
-    "@sap/hdi-deploy": "^3",
-    "@sap/cds-dk": "^3"
+    "@sap/hdi-deploy": "^3"
   },
   "scripts": {
-    "postinstall": "cd .. && db/node_modules/.bin/cds build --for hana || echo \"Skipping cds build...\"",
     "start": "node node_modules/@sap/hdi-deploy --exit"
   }
 }

--- a/db/package.json
+++ b/db/package.json
@@ -1,10 +1,11 @@
 {
   "name": "deploy",
   "dependencies": {
-    "@sap/hdi-deploy": "^3"
+    "@sap/hdi-deploy": "^3",
+    "@sap/cds-dk": "^3"
   },
   "scripts": {
-    "postinstall": "cd .. && cds build --for hana",
+    "postinstall": "cd .. && db/node_modules/.bin/cds build --for hana || echo \"Skipping cds build...\"",
     "start": "node node_modules/@sap/hdi-deploy --exit"
   }
 }

--- a/mta-multi-tenant.yaml
+++ b/mta-multi-tenant.yaml
@@ -4,6 +4,12 @@ version: 1.0.0
 description: "Multitenant Bookshop CAP Java Project with UI"
 parameters:
   enable-parallel-deployments: true
+build-parameters:
+  before-all:
+   - builder: custom
+     commands:
+      - npm install --production
+      - npx -p @sap/cds-dk cds build --production
 modules:
 # --------------------- SERVER MODULE ------------------------
   - name: bookshop-java-public-srv

--- a/mta-single-tenant.yaml
+++ b/mta-single-tenant.yaml
@@ -4,6 +4,12 @@ version: 1.0.0
 description: "Bookshop CAP Java Project with UI"
 parameters:
   enable-parallel-deployments: true
+build-parameters:
+  before-all:
+   - builder: custom
+     commands:
+      - npm install --production
+      - npx -p @sap/cds-dk cds build --production
 modules:
 # --------------------- SERVER MODULE ------------------------
   - name: bookshop-java-public-srv

--- a/mtx-sidecar/package.json
+++ b/mtx-sidecar/package.json
@@ -7,12 +7,10 @@
         "@sap/instance-manager": "^2.2.0",
         "@sap/xssec": "^3.0.9",
         "@sap/hana-client": "^2.5.105",
-        "@sap/cds-dk": "^3",
         "express": "^4.17.1",
         "passport": "^0.4.1"
     },
     "scripts": {
-        "postinstall": "cd .. && mtx-sidecar/node_modules/.bin/cds build --for mtx || echo \"Skipping cds build...\"",
         "start": "node server.js"
     }
 }

--- a/mtx-sidecar/package.json
+++ b/mtx-sidecar/package.json
@@ -7,11 +7,12 @@
         "@sap/instance-manager": "^2.2.0",
         "@sap/xssec": "^3.0.9",
         "@sap/hana-client": "^2.5.105",
+        "@sap/cds-dk": "^3",
         "express": "^4.17.1",
         "passport": "^0.4.1"
     },
     "scripts": {
-        "postinstall": "cd .. && cds build --for mtx",
+        "postinstall": "cd .. && mtx-sidecar/node_modules/.bin/cds build --for mtx || echo \"Skipping cds build...\"",
         "start": "node server.js"
     }
 }


### PR DESCRIPTION
Previously the build of the mtx-sidecar and db module required a
globally installed cds-dk, which is not fulfilled for pipeline builds or
staging on CF.