### PR TITLE
Don't mix destination configuration with SAP API Business Hub API Key

### DIFF
--- a/srv/src/main/java/my/bookshop/handlers/DestinationConfiguration.java
+++ b/srv/src/main/java/my/bookshop/handlers/DestinationConfiguration.java
@@ -15,7 +15,7 @@ import com.sap.cloud.sdk.cloudplatform.connectivity.DestinationAccessor;
 @ServiceName(ApplicationLifecycleService.DEFAULT_NAME)
 public class DestinationConfiguration implements EventHandler {
 
-	@Value("${cds.remote.services[0].destination.api-key:}")
+	@Value("${api-hub.api-key:}")
 	private String apiKey;
 
 	@Before(event = ApplicationLifecycleService.EVENT_APPLICATION_PREPARED)

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -31,8 +31,8 @@ cds:
       name: "s4-business-partner-api"
       suffix: "sap/opu/odata/sap/"
       type: "odata-v2"
-      api-key: "" # Place API Key from API Business Hub here
-
+api-hub:
+  api-key: "" # Place API Key from SAP API Business Hub here
 ---
 spring:
   config.activate.on-profile: sqlite


### PR DESCRIPTION
Reading the API Key is explicitly implemented in this sample application.
Adding that configuration to the destination configuration of a Remote Service creates the impression that this is natively supported by CAP.
This is however not the case. It also promotes the bad behaviour of extending CAPs configuration schemas with custom properties.