### PR TITLE
Fix annotation name

### DIFF
--- a/db/reviews.cds
+++ b/db/reviews.cds
@@ -19,7 +19,7 @@ entity Reviews : cuid, managed {
 annotate Reviews with {
     subject @mandatory;
     title @mandatory;
-    rating @assert.enum;
+    rating @assert.range;
 }
 
 type Rating : Integer enum {


### PR DESCRIPTION
Annotation to assert enums is called `@assert.range`, see also https://cap.cloud.sap/docs/guides/generic#assertrange-check-constraints