### PR TITLE
Improved robustness of setIsReviewable

### DIFF
--- a/srv/src/main/java/my/bookshop/handlers/CatalogServiceHandler.java
+++ b/srv/src/main/java/my/bookshop/handlers/CatalogServiceHandler.java
@@ -143,7 +143,8 @@ class CatalogServiceHandler implements EventHandler {
 	@After
 	public void setIsReviewable(CdsReadEventContext context, List<Books> books) {
 		String user = context.getUserInfo().getName();
-		List<String> bookIds = books.stream().map(b -> b.getId()).collect(Collectors.toList());
+		List<String> bookIds = books.stream().filter(b -> b.getId() != null).map(b -> b.getId())
+				.collect(Collectors.toList());
 
 		CqnSelect query = Select.from(CatalogService_.BOOKS, b -> b.filter(b.ID().in(bookIds)).reviews())
 				.where(r -> r.createdBy().eq(user));

--- a/srv/src/main/java/my/bookshop/handlers/CatalogServiceHandler.java
+++ b/srv/src/main/java/my/bookshop/handlers/CatalogServiceHandler.java
@@ -146,6 +146,10 @@ class CatalogServiceHandler implements EventHandler {
 		List<String> bookIds = books.stream().filter(b -> b.getId() != null).map(b -> b.getId())
 				.collect(Collectors.toList());
 
+		if (bookIds.isEmpty()) {
+			return;
+		}
+		
 		CqnSelect query = Select.from(CatalogService_.BOOKS, b -> b.filter(b.ID().in(bookIds)).reviews())
 				.where(r -> r.createdBy().eq(user));
 


### PR DESCRIPTION
(please don't mind the incorrect branch name, it should rather be read-books-handler-robustness)
- we cannot rely on always having the id property of books here
- a request on books(ID=...)/title for example would run into an NPE