### PR TITLE
Allow forking a subprocess to support Spring Boot Developer Tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<version>${spring.boot.version}</version>
 				<configuration>
-					<fork>false</fork>
 					<skip>true</skip>
 				</configuration>
 			</plugin>

--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -86,6 +86,8 @@
 				<version>${spring.boot.version}</version>
 				<configuration>
 					<skip>false</skip>
+					<!-- use project root directory as working directory to deliver fiori resources -->
+					<workingDirectory>..</workingDirectory>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
- Disabling forks also disables the Spring Developer Tools in the application
- see: https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#goals-run-parameters-details-fork