### PR TITLE
Avoid Pitfalls in MTA deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,16 +189,16 @@ Deploy as Single Tenant Application:
 - Rename `mta-single-tenant.yaml` to `mta.yaml`
 - Run `mbt build`
 - Run `cf login`
-- Run `cf deploy mta_archives/bookshop-java-public_1.0.0.mtar`
+- Run `cf deploy mta_archives/bookshop_1.0.0.mtar`
 
 Deploy as Multitenant Application:
-- Create an SAP HANA Cloud Instance in your SAP Business Technology Platform space.
+- [Create a SAP HANA Cloud Instance](https://developers.sap.com/tutorials/hana-cloud-deploying.html) in your SAP Business Technology Platform space.
 - Rename `mta-multi-tenant.yaml` to `mta.yaml`
 - Run `mbt build`
 - Run `cf login`
-- Run `cf deploy mta_archives/bookshop-java-public_1.0.0.mtar`
+- Run `cf deploy mta_archives/bookshop-mt_1.0.0.mtar`
 - Go to another subaccount in your global account, under subscriptions and subscribe to the application you deployed.
-- Run `cf map-route bookshop-java-public-approuter <YOUR DOMAIN> --hostname <SUBSCRIBER TENANT>-<ORG>-<SPACE>-bookshop-java-public-approuter` or create and bind the route manually.
+- Run `cf map-route bookshop-mt-app <YOUR DOMAIN> --hostname <SUBSCRIBER TENANT>-<ORG>-<SPACE>-bookshop-mt-app` or create and bind the route manually.
 
 # Code Tour
 

--- a/mta-multi-tenant.yaml
+++ b/mta-multi-tenant.yaml
@@ -1,5 +1,5 @@
 _schema-version: '2.1'
-ID: bookshop-java-public
+ID: bookshop-mt
 version: 1.0.0
 description: "Multitenant Bookshop CAP Java Project with UI"
 parameters:
@@ -12,7 +12,7 @@ build-parameters:
       - npx -p @sap/cds-dk cds build --production
 modules:
 # --------------------- SERVER MODULE ------------------------
-  - name: bookshop-java-public-srv
+  - name: bookshop-mt-srv
 # ------------------------------------------------------------
     type: java
     path: srv
@@ -29,9 +29,9 @@ modules:
         - mvn clean package -DskipTests=true
       build-result: target/*-exec.jar
     requires:
-      - name: bookshop-java-public-service-manager
-      - name: bookshop-java-public-uaa
-      - name: bookshop-java-public-saas-registry
+      - name: bookshop-mt-service-manager
+      - name: bookshop-mt-uaa
+      - name: bookshop-mt-saas-registry
       - name: sidecar
         properties:
           CDS_MULTITENANCY_SIDECAR_URL: ~{url}
@@ -43,7 +43,7 @@ modules:
         properties:
           url: '${default-url}'
 # --------------------- SIDECAR MODULE -----------------------
-  - name: bookshop-java-public-sidecar
+  - name: bookshop-mt-sidecar
 # ------------------------------------------------------------
     type: nodejs
     path: mtx-sidecar
@@ -51,14 +51,14 @@ modules:
       memory: 256M
       disk-quota: 512M
     requires:
-      - name: bookshop-java-public-service-manager
-      - name: bookshop-java-public-uaa
+      - name: bookshop-mt-service-manager
+      - name: bookshop-mt-uaa
     provides:
       - name: sidecar
         properties:
           url: ${default-url}
 # --------------------- APPROUTER MODULE ---------------------
-  - name: bookshop-java-public-approuter
+  - name: bookshop-mt-app
 # ------------------------------------------------------------
     type: nodejs
     path: app
@@ -75,7 +75,7 @@ modules:
         url: ~{url}
         forwardAuthToken: true
         strictSSL: true
-    - name: bookshop-java-public-uaa
+    - name: bookshop-mt-uaa
     provides:
       - name: app
         properties:
@@ -83,27 +83,27 @@ modules:
 # --------------------- RESOURCES ---------------------
 resources:
 # -----------------------------------------------------
-  - name: bookshop-java-public-uaa
+  - name: bookshop-mt-uaa
     type: com.sap.xs.uaa
     parameters:
       service: xsuaa
       service-plan: broker
       path: ./cds-security-mt.json
       config: # override xsappname in cds-security.json, xsappname needs to be unique
-        xsappname: bookshop-java-public-${org}-${space}
-  - name: bookshop-java-public-service-manager
+        xsappname: bookshop-mt-${org}-${space}
+  - name: bookshop-mt-service-manager
     type: org.cloudfoundry.managed-service
     parameters:
       service: service-manager
       service-plan: container
-  - name: bookshop-java-public-saas-registry
+  - name: bookshop-mt-saas-registry
     type: org.cloudfoundry.managed-service
     parameters:
       service: saas-registry
       service-plan: application
       config:
-         appName: bookshop-java-public-${org}-${space} # this is the text on the tile
-         xsappname: bookshop-java-public-${org}-${space} # this is the value from xsuaa.parameters.config.xsappname
+         appName: bookshop-mt-${org}-${space} # this is the text on the tile
+         xsappname: bookshop-mt-${org}-${space} # this is the value from xsuaa.parameters.config.xsappname
          appUrls:
            getDependencies: ~{srv/url}/mt/v1.0/subscriptions/dependencies
            onSubscription: ~{srv/url}/mt/v1.0/subscriptions/tenants/{tenantId}

--- a/mta-single-tenant.yaml
+++ b/mta-single-tenant.yaml
@@ -1,5 +1,5 @@
 _schema-version: '2.1'
-ID: bookshop-java-public
+ID: bookshop
 version: 1.0.0
 description: "Bookshop CAP Java Project with UI"
 parameters:
@@ -12,7 +12,7 @@ build-parameters:
       - npx -p @sap/cds-dk cds build --production
 modules:
 # --------------------- SERVER MODULE ------------------------
-  - name: bookshop-java-public-srv
+  - name: bookshop-srv
 # ------------------------------------------------------------
     type: java
     path: srv
@@ -28,14 +28,14 @@ modules:
         - mvn clean package -DskipTests=true
       build-result: target/*-exec.jar
     requires:
-      - name: bookshop-java-public-hdi-container
-      - name: bookshop-java-public-uaa
+      - name: bookshop-hdi-container
+      - name: bookshop-uaa
     provides:
       - name: srv
         properties:
           url: '${default-url}'
 # --------------------- DB MODULE ---------------------------
-  - name: bookshop-java-public-db
+  - name: bookshop-db
 # -----------------------------------------------------------
     type: nodejs
     path: db
@@ -49,9 +49,9 @@ modules:
         command: npm run start
     requires:
       # Set user and password to secure rest API via basic authentication
-      - name: bookshop-java-public-hdi-container
+      - name: bookshop-hdi-container
 # --------------------- APPROUTER MODULE ---------------------
-  - name: bookshop-java-public-approuter
+  - name: bookshop-app
 # ------------------------------------------------------------
     type: nodejs
     path: app
@@ -66,7 +66,7 @@ modules:
         url: ~{url}
         forwardAuthToken: true
         strictSSL: true
-    - name: bookshop-java-public-uaa
+    - name: bookshop-uaa
     provides:
       - name: app
         properties:
@@ -74,15 +74,15 @@ modules:
 # --------------------- RESOURCES ---------------------
 resources:
 # -----------------------------------------------------
-  - name: bookshop-java-public-uaa
+  - name: bookshop-uaa
     type: com.sap.xs.uaa
     parameters:
       service: xsuaa
       service-plan: broker
       path: ./cds-security.json
       config: # override xsappname in cds-security.json, xsappname needs to be unique
-        xsappname: bookshop-java-public-${org}-${space}
-  - name: bookshop-java-public-hdi-container
+        xsappname: bookshop-${org}-${space}
+  - name: bookshop-hdi-container
     type: org.cloudfoundry.managed-service
     parameters:
       service: hanatrial


### PR DESCRIPTION
- Shorter app and hostnames to avoid errors with routes over 63 characters
- Make singletenant and multitenant deployable in the same space
- Add link to tutorial explaining how to create SAP HANA Cloud instance