### PR TITLE
remove obsolete build task config from mtx-sidecar

### DIFF
--- a/mtx-sidecar/.cdsrc.json
+++ b/mtx-sidecar/.cdsrc.json
@@ -5,26 +5,10 @@
     "build": {
         "tasks": [
             {
-                "for": "hana",
-                "src": "db",
-                "options": {
-                    "model": [
-                        "db",
-                        "srv",
-                        "app"
-                    ]
-                }
+                "for": "hana"
             },
             {
-                "for": "java-cf",
-                "src": "srv",
-                "options": {
-                    "model": [
-                        "db",
-                        "srv",
-                        "app"
-                    ]
-                }
+                "for": "java-cf"
             }
         ]
     },


### PR DESCRIPTION
- defaults build task config can be ommitted