### PR TITLE
Prepare applications for use with Launchpad Service and HTML5 repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ hs_err*
 .DS_Store
 
 *.db
+
+.cdsrc-private.json

--- a/app/addresses/package.json
+++ b/app/addresses/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "addresses",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/app/addresses/webapp/manifest.json
+++ b/app/addresses/webapp/manifest.json
@@ -5,6 +5,9 @@
         "type": "application",
         "title": "{{appTitle}}",
         "description": "{{appDescription}}",
+        "applicationVersion": {
+            "version": "1.0.0"
+        },
         "dataSources": {
             "NotesService": {
                 "uri": "/api/notes/",

--- a/app/addresses/webapp/manifest.json
+++ b/app/addresses/webapp/manifest.json
@@ -24,13 +24,13 @@
         },
         "crossNavigation": {
             "inbounds": {
-                "Addresses-manage": {
+                "Addresses-show": {
                     "signature": {
                         "parameters": {},
                         "additionalParameters": "allowed"
                     },
                     "semanticObject": "Addresses",
-                    "action": "manage"
+                    "action": "show"
                 }
             }
         }

--- a/app/addresses/webapp/manifest.json
+++ b/app/addresses/webapp/manifest.json
@@ -21,6 +21,18 @@
             "id": "ui5template.basicSAPUI5ApplicationProject",
             "-id": "ui5template.smartTemplate",
             "-version": "1.40.12"
+        },
+        "crossNavigation": {
+            "inbounds": {
+                "Addresses-manage": {
+                    "signature": {
+                        "parameters": {},
+                        "additionalParameters": "allowed"
+                    },
+                    "semanticObject": "Addresses",
+                    "action": "manage"
+                }
+            }
         }
     },
     "sap.ui5": {

--- a/app/admin/package.json
+++ b/app/admin/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "admin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/app/admin/webapp/manifest.json
+++ b/app/admin/webapp/manifest.json
@@ -21,6 +21,18 @@
             "id": "ui5template.basicSAPUI5ApplicationProject",
             "-id": "ui5template.smartTemplate",
             "-version": "1.40.12"
+        },
+        "crossNavigation": {
+            "inbounds": {
+                "Admin-manage": {
+                    "signature": {
+                        "parameters": {},
+                        "additionalParameters": "allowed"
+                    },
+                    "semanticObject": "Admin",
+                    "action": "manage"
+                }
+            }
         }
     },
     "sap.ui5": {

--- a/app/admin/webapp/manifest.json
+++ b/app/admin/webapp/manifest.json
@@ -5,6 +5,9 @@
         "type": "application",
         "title": "{{appTitle}}",
         "description": "{{appDescription}}",
+        "applicationVersion": {
+            "version": "1.0.0"
+        },
         "dataSources": {
             "AdminService": {
                 "uri": "/api/admin/",

--- a/app/admin/webapp/manifest.json
+++ b/app/admin/webapp/manifest.json
@@ -24,12 +24,12 @@
         },
         "crossNavigation": {
             "inbounds": {
-                "Admin-manage": {
+                "Books-manage": {
                     "signature": {
                         "parameters": {},
                         "additionalParameters": "allowed"
                     },
-                    "semanticObject": "Admin",
+                    "semanticObject": "Books",
                     "action": "manage"
                 }
             }

--- a/app/browse/package.json
+++ b/app/browse/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "browse",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/app/browse/webapp/manifest.json
+++ b/app/browse/webapp/manifest.json
@@ -24,13 +24,13 @@
         },
         "crossNavigation": {
             "inbounds": {
-                "Books-manage": {
+                "Books-show": {
                     "signature": {
                         "parameters": {},
                         "additionalParameters": "allowed"
                     },
                     "semanticObject": "Books",
-                    "action": "manage"
+                    "action": "show"
                 }
             }
         }

--- a/app/browse/webapp/manifest.json
+++ b/app/browse/webapp/manifest.json
@@ -5,6 +5,9 @@
         "type": "application",
         "title": "{{appTitle}}",
         "description": "{{appDescription}}",
+        "applicationVersion": {
+            "version": "1.0.0"
+        },
         "dataSources": {
             "CatalogService": {
                 "uri": "/api/browse/",
@@ -18,6 +21,18 @@
             "id": "ui5template.basicSAPUI5ApplicationProject",
             "-id": "ui5template.smartTemplate",
             "-version": "1.40.12"
+        },
+        "crossNavigation": {
+            "inbounds": {
+                "Books-manage": {
+                    "signature": {
+                        "parameters": {},
+                        "additionalParameters": "allowed"
+                    },
+                    "semanticObject": "Books",
+                    "action": "manage"
+                }
+            }
         }
     },
     "sap.ui5": {

--- a/app/notes/package.json
+++ b/app/notes/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "notes",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/app/notes/webapp/manifest.json
+++ b/app/notes/webapp/manifest.json
@@ -5,6 +5,9 @@
         "type": "application",
         "title": "{{appTitle}}",
         "description": "{{appDescription}}",
+        "applicationVersion": {
+            "version": "1.0.0"
+        },
         "dataSources": {
             "NotesService": {
                 "uri": "/api/notes/",
@@ -18,6 +21,18 @@
             "id": "ui5template.basicSAPUI5ApplicationProject",
             "-id": "ui5template.smartTemplate",
             "-version": "1.40.12"
+        },
+        "crossNavigation": {
+            "inbounds": {
+                "Notes-manage": {
+                    "signature": {
+                        "parameters": {},
+                        "additionalParameters": "allowed"
+                    },
+                    "semanticObject": "Notes",
+                    "action": "manage"
+                }
+            }
         }
     },
     "sap.ui5": {

--- a/app/orders/package.json
+++ b/app/orders/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "orders",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/app/orders/webapp/manifest.json
+++ b/app/orders/webapp/manifest.json
@@ -5,9 +5,9 @@
 		"type": "application",
 		"title": "{{appTitle}}",
 		"description": "{{appDescription}}",
-        "applicationVersion": {
-            "version": "1.0.0"
-        },
+		"applicationVersion": {
+			"version": "1.0.0"
+		},
 		"dataSources": {
 			"AdminService": {
 				"uri": "/api/admin/",
@@ -17,30 +17,30 @@
 				}
 			}
 		},
-        "-sourceTemplate": {
-            "id": "ui5template.basicSAPUI5ApplicationProject",
+		"-sourceTemplate": {
+			"id": "ui5template.basicSAPUI5ApplicationProject",
 			"-id": "ui5template.smartTemplate",
 			"-version": "1.40.12"
 		},
-        "crossNavigation": {
-            "inbounds": {
-                "Orders-manage": {
-                    "signature": {
-                        "parameters": {},
-                        "additionalParameters": "allowed"
-                    },
-                    "semanticObject": "Orders",
-                    "action": "manage"
-                }
-            }
-        }
+		"crossNavigation": {
+			"inbounds": {
+				"Orders-manage": {
+					"signature": {
+						"parameters": {},
+						"additionalParameters": "allowed"
+					},
+					"semanticObject": "Orders",
+					"action": "manage"
+				}
+			}
+		}
 	},
 	"sap.ui5": {
-        "dependencies": {
-            "libs": {
-                "sap.fe.templates": {}
-            }
-        },
+		"dependencies": {
+			"libs": {
+				"sap.fe.templates": {}
+			}
+		},
 		"models": {
 			"i18n": {
 				"type": "sap.ui.model.resource.ResourceModel",
@@ -49,47 +49,47 @@
 			"": {
 				"dataSource": "AdminService",
 				"settings": {
-                    "synchronizationMode": "None",
-                    "operationMode": "Server",
-                    "autoExpandSelect" : true,
-                    "earlyRequests": true,
-                    "groupProperties": {
-                        "default": {
-                          "submit": "Auto"
-                        }
-                    }
+					"synchronizationMode": "None",
+					"operationMode": "Server",
+					"autoExpandSelect" : true,
+					"earlyRequests": true,
+					"groupProperties": {
+						"default": {
+						  "submit": "Auto"
+						}
+					}
 				}
 			}
 		},
-        "routing": {
-            "routes": [
-                {
-                    "pattern": ":?query:",
-                    "name": "OrdersList",
-                    "target": "OrdersList"
-                },
-                {
-                    "pattern": "Orders({key}):?query:",
-                    "name": "OrdersDetails",
-                    "target": "OrdersDetails"
-                },
-                {
-                    "pattern": "Orders({boo})/Items({boo2}):?query:",
-                    "name": "OrderItemsDetails",
-                    "target": "OrderItemsDetails"
-                },
-                {
-                    "pattern": "Books({key}):?query:",
-                    "name": "BooksDetails",
-                    "target": "BooksDetails"
-                }
-            ],
-            "targets": {
-                "OrdersList": {
-                    "type": "Component",
-                    "id": "OrdersList",
-                    "name": "sap.fe.templates.ListReport",
-                    "options": {
+		"routing": {
+			"routes": [
+				{
+					"pattern": ":?query:",
+					"name": "OrdersList",
+					"target": "OrdersList"
+				},
+				{
+					"pattern": "Orders({key}):?query:",
+					"name": "OrdersDetails",
+					"target": "OrdersDetails"
+				},
+				{
+					"pattern": "Orders({boo})/Items({boo2}):?query:",
+					"name": "OrderItemsDetails",
+					"target": "OrderItemsDetails"
+				},
+				{
+					"pattern": "Books({key}):?query:",
+					"name": "BooksDetails",
+					"target": "BooksDetails"
+				}
+			],
+			"targets": {
+				"OrdersList": {
+					"type": "Component",
+					"id": "OrdersList",
+					"name": "sap.fe.templates.ListReport",
+					"options": {
 						"settings" : {
 							"entitySet" : "Orders",
 							"navigation" : {
@@ -101,73 +101,73 @@
 							}
 						}
 					}
-                },
-                "OrdersDetails": {
-                    "type": "Component",
-                    "id": "OrdersDetails",
-                    "name": "sap.fe.templates.ObjectPage",
-                    "options": {
-                        "settings" : {
-                            "entitySet": "Orders",
+				},
+				"OrdersDetails": {
+					"type": "Component",
+					"id": "OrdersDetails",
+					"name": "sap.fe.templates.ObjectPage",
+					"options": {
+						"settings" : {
+							"entitySet": "Orders",
 							"navigation" : {
 								"Items": {
-                                    "detail": {
-                                        "route": "OrderItemsDetails"
-                                    }
-                                },
-                                "book": {
-                                    "detail": {
-                                        "route": "BooksDetails"
-                                    }
-                                },
-                                "dummy": {
-                                    "detail": {
-                                        "route": "BooksDetails"
-                                    }
-                                }
+									"detail": {
+										"route": "OrderItemsDetails"
+									}
+								},
+								"book": {
+									"detail": {
+										"route": "BooksDetails"
+									}
+								},
+								"dummy": {
+									"detail": {
+										"route": "BooksDetails"
+									}
+								}
 							}
 						}
 					}
-                },
-                "OrderItemsDetails": {
-                    "type": "Component",
-                    "id": "OrderItemsDetails",
-                    "name": "sap.fe.templates.ObjectPage",
-                    "options": {
-                        "settings" : {
-                            "entitySet": "OrderItems"
-                        }
-                    }
-                },
-                "BooksDetails": {
-                    "type": "Component",
-                    "id": "BooksDetails",
-                    "name": "sap.fe.templates.ObjectPage",
-                    "options": {
-                        "settings" : {
-                            "entitySet": "Books",
-                            "navigation": {
-                                "author": {
-                                    "detail": {
-                                        "route": "AuthorsDetails"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "AuthorsDetails": {
-                    "type": "Component",
-                    "id": "AuthorsDetails",
-                    "name": "sap.fe.templates.ObjectPage",
-                    "options": {
-                        "settings" : {
-                            "entitySet": "Authors"
-                        }
-                    }
-                }
-            }
-        },
+				},
+				"OrderItemsDetails": {
+					"type": "Component",
+					"id": "OrderItemsDetails",
+					"name": "sap.fe.templates.ObjectPage",
+					"options": {
+						"settings" : {
+							"entitySet": "OrderItems"
+						}
+					}
+				},
+				"BooksDetails": {
+					"type": "Component",
+					"id": "BooksDetails",
+					"name": "sap.fe.templates.ObjectPage",
+					"options": {
+						"settings" : {
+							"entitySet": "Books",
+							"navigation": {
+								"author": {
+									"detail": {
+										"route": "AuthorsDetails"
+									}
+								}
+							}
+						}
+					}
+				},
+				"AuthorsDetails": {
+					"type": "Component",
+					"id": "AuthorsDetails",
+					"name": "sap.fe.templates.ObjectPage",
+					"options": {
+						"settings" : {
+							"entitySet": "Authors"
+						}
+					}
+				}
+			}
+		},
 		"contentDensities": {
 			"compact": true,
 			"cozy": true

--- a/app/orders/webapp/manifest.json
+++ b/app/orders/webapp/manifest.json
@@ -5,6 +5,9 @@
 		"type": "application",
 		"title": "{{appTitle}}",
 		"description": "{{appDescription}}",
+        "applicationVersion": {
+            "version": "1.0.0"
+        },
 		"dataSources": {
 			"AdminService": {
 				"uri": "/api/admin/",
@@ -18,7 +21,19 @@
             "id": "ui5template.basicSAPUI5ApplicationProject",
 			"-id": "ui5template.smartTemplate",
 			"-version": "1.40.12"
-		}
+		},
+        "crossNavigation": {
+            "inbounds": {
+                "Orders-manage": {
+                    "signature": {
+                        "parameters": {},
+                        "additionalParameters": "allowed"
+                    },
+                    "semanticObject": "Orders",
+                    "action": "manage"
+                }
+            }
+        }
 	},
 	"sap.ui5": {
         "dependencies": {

--- a/app/reviews/package.json
+++ b/app/reviews/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "reviews",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/app/reviews/webapp/manifest.json
+++ b/app/reviews/webapp/manifest.json
@@ -5,6 +5,9 @@
         "type": "application",
         "title": "{{appTitle}}",
         "description": "{{appDescription}}",
+        "applicationVersion": {
+            "version": "1.0.0"
+        },
         "dataSources": {
             "ReviewService": {
                 "uri": "/api/review/",
@@ -18,6 +21,18 @@
             "id": "ui5template.basicSAPUI5ApplicationProject",
             "-id": "ui5template.smartTemplate",
             "-version": "1.40.12"
+        },
+        "crossNavigation": {
+            "inbounds": {
+                "Reviews-manage": {
+                    "signature": {
+                        "parameters": {},
+                        "additionalParameters": "allowed"
+                    },
+                    "semanticObject": "Reviews",
+                    "action": "manage"
+                }
+            }
         }
     },
     "sap.ui5": {


### PR DESCRIPTION
The changes are a precondition to deploy the UI5 applications in the `app` folder to the HTML5 repo and use them in the SAP BTP Launchpad Service. The changes for the `mta.yaml` deployment descriptor are not included.

* Added `package.json` required to run the UI5 build
* Added `applicationVersion` in `manifest.json` files to deploy to HTML5 repo
* Added `crossNavigation` in `manifest.json` files to add application as Launchpad tiles 