### PR TITLE
Disable RequestLogger in non-cloud profile

### DIFF
--- a/srv/src/main/resources/logback-spring.xml
+++ b/srv/src/main/resources/logback-spring.xml
@@ -11,5 +11,6 @@
     </springProfile>
     <springProfile name="!cloud">
         <include resource="org/springframework/boot/logging/logback/base.xml" />
+        <logger name="com.sap.hcp.cf.logging.servlet.filter.RequestLogger" level="WARN" />
     </springProfile>
 </configuration>


### PR DESCRIPTION
Without the JsonEncoder the RequestLogger is no longer able to write request logs.
See also: https://github.com/SAP/cf-java-logging-support/issues/149