### PR TITLE
Make CatalogService public again

### DIFF
--- a/srv/cat-service.cds
+++ b/srv/cat-service.cds
@@ -1,7 +1,7 @@
 using {my.bookshop as my} from '../db/index';
 
 @path : 'browse'
-service CatalogService {
+service CatalogService @(requires: 'any') {
     @readonly
     entity Books       as projection on my.Books excluding {
         createdBy,

--- a/srv/src/test/java/my/bookshop/CatalogServiceITest.java
+++ b/srv/src/test/java/my/bookshop/CatalogServiceITest.java
@@ -34,7 +34,6 @@ public class CatalogServiceITest {
 
 	private static final String USER_USER_STRING = "user";
 	private static final String ADMIN_USER_STRING = "admin";
-	private static final String AUTHENTICATED_USER_STRING = "authenticated"; // given by default
 
 	@Autowired
 	private MockMvc mockMvc;
@@ -48,7 +47,6 @@ public class CatalogServiceITest {
 	}
 
 	@Test
-	@WithMockUser(AUTHENTICATED_USER_STRING)
 	public void testDiscountApplied() throws Exception {
 		mockMvc.perform(get(booksURI + "?$filter=stock gt 200&top=1"))
 			.andExpect(status().isOk())
@@ -56,7 +54,6 @@ public class CatalogServiceITest {
 	}
 
 	@Test
-	@WithMockUser(AUTHENTICATED_USER_STRING)
 	public void testDiscountNotApplied() throws Exception {
 		mockMvc.perform(get(booksURI + "?$filter=stock lt 100&top=1"))
 			.andExpect(status().isOk())
@@ -67,7 +64,7 @@ public class CatalogServiceITest {
 	public void testCreateReviewNotAuthenticated() throws Exception {
 		String payload = createTestReview().toJson();
 		mockMvc.perform(post(addReviewURI).contentType(MediaType.APPLICATION_JSON).content(payload))
-			.andExpect(status().isUnauthorized());
+			.andExpect(status().isForbidden());
 	}
 
 	@Test


### PR DESCRIPTION
Partially reverts https://github.com/SAP-samples/cloud-cap-samples-java/pull/156, now that we can reasonably opt-out of secure-by-default.