### PR TITLE
Update CDS Services to 1.29.0

### DIFF
--- a/.cdsrc.json
+++ b/.cdsrc.json
@@ -3,7 +3,7 @@
         "target": ".",
         "tasks": [
             {
-                "for": "java-cf"
+                "for": "java"
             },
             {
                 "for": "mtx",
@@ -17,8 +17,5 @@
     },
     "hana": {
         "deploy-format": "hdbtable"
-    },
-    "sql": {
-        "dialect": "plain"
     }
 }

--- a/mtx-sidecar/.cdsrc.json
+++ b/mtx-sidecar/.cdsrc.json
@@ -8,7 +8,7 @@
                 "for": "hana"
             },
             {
-                "for": "java-cf"
+                "for": "java"
             }
         ]
     },

--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,12 @@
 
 		<!-- DEPENDENCIES VERSION -->
 		<jdk.version>1.8</jdk.version>
-		<cds.services.version>1.28.1</cds.services.version>
-		<spring.boot.version>2.7.4</spring.boot.version>
-		<cloud.sdk.version>3.75.0</cloud.sdk.version>
+		<cds.services.version>1.29.0</cds.services.version>
+		<spring.boot.version>2.7.5</spring.boot.version>
+		<cloud.sdk.version>4.0.0</cloud.sdk.version>
 		<xsuaa.version>2.13.3</xsuaa.version>
-		<cf-java-logging-support.version>3.6.2</cf-java-logging-support.version>
-		<cds.install-cdsdk.version>^6</cds.install-cdsdk.version>
+		<cf-java-logging-support.version>3.6.3</cf-java-logging-support.version>
+		<cds.install-cdsdk.version>6.3.0</cds.install-cdsdk.version>
 	</properties>
 
 	<modules>
@@ -64,13 +64,6 @@
 				<version>${xsuaa.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			
-			<!-- pin H2 v1 -->
-			<dependency>
-				<groupId>com.h2database</groupId>
-				<artifactId>h2</artifactId>
-				<version>1.4.200</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/srv/external/API_BUSINESS_PARTNER.csn
+++ b/srv/external/API_BUSINESS_PARTNER.csn
@@ -2135,8 +2135,7 @@
         },
         "CheckPaidDurationInDays": {
           "type": "cds.Decimal",
-          "precision": 3,
-          "scale": 0
+          "precision": 3
         },
         "Currency": {
           "type": "cds.String",
@@ -2378,8 +2377,7 @@
         },
         "MaterialPlannedDeliveryDurn": {
           "type": "cds.Decimal",
-          "precision": 3,
-          "scale": 0
+          "precision": 3
         },
         "MinimumOrderAmount": {
           "type": "cds.Decimal",

--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -178,10 +178,10 @@
 						</goals>
 						<configuration>
 							<commands>
-								<command>build --for java-cf</command>
-								<command>deploy --to sql --with-mocks --dry >
+								<command>build --for java</command>
+								<command>deploy --to h2 --with-mocks --dry >
 									${project.basedir}/src/main/resources/schema.sql</command>
-								<command>deploy --to sql --dry >
+								<command>deploy --to h2 --dry >
 									${project.basedir}/src/main/resources/schema-nomocks.sql</command>
 								<command>compile srv/cat-service.cds -2 openapi --openapi:url /api/browse >
 									${project.basedir}/src/main/resources/swagger/openapi.json</command>


### PR DESCRIPTION
- Use H2 v2 with new h2 dialect provided by CDS Compiler
- Use new name java instead of old java-cf for build tasks
- Update dependencies