### PR TITLE
Update @sap/cds-dk to 6.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<cloud.sdk.version>4.0.0</cloud.sdk.version>
 		<xsuaa.version>2.13.3</xsuaa.version>
 		<cf-java-logging-support.version>3.6.3</cf-java-logging-support.version>
-		<cds.install-cdsdk.version>6.3.0</cds.install-cdsdk.version>
+		<cds.install-cdsdk.version>6.3.1</cds.install-cdsdk.version>
 	</properties>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<cloud.sdk.version>4.0.0</cloud.sdk.version>
 		<xsuaa.version>2.13.3</xsuaa.version>
 		<cf-java-logging-support.version>3.6.3</cf-java-logging-support.version>
-		<cds.install-cdsdk.version>6.3.1</cds.install-cdsdk.version>
+		<cds.install-cdsdk.version>6.3.2</cds.install-cdsdk.version>
 	</properties>
 
 	<modules>

--- a/srv/external/API_BUSINESS_PARTNER.csn
+++ b/srv/external/API_BUSINESS_PARTNER.csn
@@ -2135,7 +2135,8 @@
         },
         "CheckPaidDurationInDays": {
           "type": "cds.Decimal",
-          "precision": 3
+          "precision": 3,
+          "scale": 0
         },
         "Currency": {
           "type": "cds.String",
@@ -2377,7 +2378,8 @@
         },
         "MaterialPlannedDeliveryDurn": {
           "type": "cds.Decimal",
-          "precision": 3
+          "precision": 3,
+          "scale": 0
         },
         "MinimumOrderAmount": {
           "type": "cds.Decimal",


### PR DESCRIPTION
Fixes H2 SQL issue, which required a small change to the original API_BUSINESS_PARTNER API