### PR TITLE
remove cds-dk installation from build script of db

### DIFF
--- a/db/package.json
+++ b/db/package.json
@@ -8,6 +8,6 @@
   },
   "scripts": {
     "start": "node node_modules/@sap/hdi-deploy/deploy.js",
-    "build": "npm i && npx -p @sap/cds-dk@^6 cds build .. --for hana --production"
+    "build": "npm i && npx cds build .. --for hana --production"
   }
 }

--- a/mta-single-tenant.yaml
+++ b/mta-single-tenant.yaml
@@ -40,6 +40,8 @@ modules:
       builder: custom
       commands:
         - npm run build
+      requires:
+        - name: bookshop-srv
     requires:
       - name: bookshop-hdi-container
 # --------------------- APPROUTER MODULE ---------------------


### PR DESCRIPTION
This PR removes the @sap/cds-dk installation from the build script in db/package.json. Now, the build script relies on a previous local installation of the cds-dk, e.g. done with a maven build. Or a globally installed cds-dk version is used.
The mbt build works fine, because first the srv module is built, then the db module.