### PR TITLE
adding .reloadtrigger to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ hs_err*
 .cdsrc-private.json
 
 /chart/
+.reloadtrigger

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<cloud.sdk.version>4.5.0</cloud.sdk.version>
 		<xsuaa.version>2.13.5</xsuaa.version>
 		<cf-java-logging-support.version>3.6.3</cf-java-logging-support.version>
-		<cds.install-cdsdk.version>6.5.1</cds.install-cdsdk.version>
+		<cds.install-cdsdk.version>6.5.2</cds.install-cdsdk.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Using the command line `mvn cds:watch` creates implicitly the file `src/main/resources/.reloadtrigger` which is not intended to be checked-in. Adding it to .gitignore solves this issue.