### PR TITLE
Version bump build plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.10.1</version>
 				<configuration>
 					<release>${jdk.version}</release>
 					<encoding>UTF-8</encoding>
@@ -95,7 +95,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M5</version>
+				<version>3.0.0-M9</version>
 				<configuration>
 					<failIfNoTests>true</failIfNoTests>
 				</configuration>
@@ -111,7 +111,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>flatten-maven-plugin</artifactId>
-				<version>1.2.5</version>
+				<version>1.3.0</version>
 				<configuration>
 					<updatePomFile>true</updatePomFile>
 					<flattenMode>resolveCiFriendliesOnly</flattenMode>
@@ -138,7 +138,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.0.0-M3</version>
+				<version>3.2.1</version>
 				<executions>
 					<execution>
 						<id>Project Structure Checks</id>


### PR DESCRIPTION
maven-compiler-plugin ............................. 3.8.1 -> 3.10.1
maven-enforcer-plugin ........................... 3.0.0-M3 -> 3.2.1
maven-surefire-plugin ........................ 3.0.0-M5 -> 3.0.0-M9 
org.codehaus.mojo:flatten-maven-plugin ............. 1.2.5 -> 1.3.0