### PR TITLE
Simplify Feature Toggles integration

### DIFF
--- a/mtx/sidecar/package.json
+++ b/mtx/sidecar/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "start": "cds run",
     "build": "npm install && npx cds build ../.. --for mtx-sidecar && cd gen && npm install",
-    "startAsync": "forever start -o out.log -e err.log -c node node_modules/@sap/cds/bin/cds.js run --profile development",
+    "startAsync": "forever start -o out.log -e err.log node_modules/.bin/cds run",
     "stopAsync": "forever stopall"
   }
 }

--- a/srv/src/main/java/my/bookshop/config/CustomFeatureToggleProvider.java
+++ b/srv/src/main/java/my/bookshop/config/CustomFeatureToggleProvider.java
@@ -1,4 +1,4 @@
-package my.bookshop;
+package my.bookshop.config;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -11,10 +11,9 @@ import com.sap.cds.services.request.ParameterInfo;
 import com.sap.cds.services.request.UserInfo;
 import com.sap.cds.services.runtime.FeatureTogglesInfoProvider;
 
-// When application executed locally, the toggles can be switched via application.yaml
 @Component
-@Profile("cloud")
-public class FeatureToggleProvider implements FeatureTogglesInfoProvider {
+@Profile("cloud") // locally, feature toggles are configured directly with mock users
+public class CustomFeatureToggleProvider implements FeatureTogglesInfoProvider {
 
 	@Override
 	public FeatureTogglesInfo get(UserInfo userInfo, ParameterInfo parameterInfo) {

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -94,6 +94,20 @@ cds:
 
 ---
 spring:
+  config.activate.on-profile: ft
+cds:
+  model.provider.url: http://localhost:4004
+  security.mock.users:
+    admin:
+      features:
+      - isbn
+      - discount
+    user:
+      features:
+      - isbn
+
+---
+spring:
   config.activate.on-profile: local-mtxs
 cds:
   multi-tenancy.sidecar.url: http://localhost:4004
@@ -109,24 +123,3 @@ spring:
 cds:
   data-source:
     auto-config.enabled: false
----
-spring:
-  config.activate.on-profile: ft
-cds:
-  model:
-    provider:
-      url: http://localhost:4004
-  datasource:
-    csv-initialization-mode: "always"
-  security:
-    defaultRestrictionLevel: "any"
-    mock.users:
-      - name: carol
-        features:
-          - isbn
-      - name: erin
-        features:
-          - isbn
-          - discount
-      - name: fred
-        features:

--- a/srv/src/test/java/my/bookshop/handlers/CatalogServiceHandlerTest.java
+++ b/srv/src/test/java/my/bookshop/handlers/CatalogServiceHandlerTest.java
@@ -4,15 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.Stream;
 
-import com.sap.cds.reflect.CdsModel;
-import com.sap.cds.services.draft.DraftService;
-import com.sap.cds.services.messages.Messages;
-import com.sap.cds.services.persistence.PersistenceService;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sap.cds.reflect.CdsModel;
+import com.sap.cds.services.draft.DraftService;
+import com.sap.cds.services.messages.Messages;
+import com.sap.cds.services.persistence.PersistenceService;
+import com.sap.cds.services.request.FeatureTogglesInfo;
 
 import cds.gen.catalogservice.Books;
 import my.bookshop.RatingCalculator;
@@ -31,6 +32,9 @@ public class CatalogServiceHandlerTest {
 	private Messages messages;
 
 	@Mock
+	private FeatureTogglesInfo featureToggles;
+
+	@Mock
 	private RatingCalculator ratingCalculator;
 
 	@Mock
@@ -45,7 +49,7 @@ public class CatalogServiceHandlerTest {
 		book2.setTitle("Book 2");
 		book2.setStock(200);
 
-		CatalogServiceHandler handler = new CatalogServiceHandler(db, reviewService, messages, ratingCalculator, model);
+		CatalogServiceHandler handler = new CatalogServiceHandler(db, reviewService, messages, featureToggles, ratingCalculator, model);
 		handler.discountBooks(Stream.of(book1, book2));
 
 		assertEquals("Book 1", book1.getTitle(), "Book 1 was discounted");


### PR DESCRIPTION
- Reuse existing mock users instead of introducing new ones
- Avoid introducing another disocunt concept and reuse the existing one