### PR TITLE
Revert "Fix enforcer plugin lifecycle mapping after upgrade to 3.2.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,6 @@
 				<version>3.2.1</version>
 				<executions>
 					<execution>
-						<?m2e ignore?>
 						<id>Project Structure Checks</id>
 						<goals>
 							<goal>enforce</goal>


### PR DESCRIPTION
Reverts SAP-samples/cloud-cap-samples-java#213

With latest IDE versions of Eclipse and VS Code no warning appears, even without this m2e setting.