### PR TITLE
Configure OAuth2 Redirect URI for XSUAA Login

### DIFF
--- a/mta-multi-tenant.yaml
+++ b/mta-multi-tenant.yaml
@@ -86,6 +86,7 @@ modules:
       - name: app-api
         properties:
           app-url: '${default-url}'
+          app-domain: '${domain}'
 # --------------------- RESOURCES ---------------------
 resources:
 # -----------------------------------------------------
@@ -99,7 +100,9 @@ resources:
         xsappname: bookshop-mt-${org}-${space}
         oauth2-configuration:
           redirect-uris:
-          - 'https://*.${default-domain}' # testing only, use custom domain with wildcard for production
+          - https://*.~{app-api/app-domain}/**
+    requires:
+      - name: app-api
   - name: bookshop-mt-service-manager
     type: org.cloudfoundry.managed-service
     parameters:

--- a/mta-multi-tenant.yaml
+++ b/mta-multi-tenant.yaml
@@ -72,7 +72,7 @@ modules:
       disk-quota: 512M
       keep-existing-routes: true
     properties:
-      TENANT_HOST_PATTERN: ^(.*)-${default-uri}
+      TENANT_HOST_PATTERN: ^(.*)-${default-uri} # testing only, use custom domain with wildcard for production
     requires:
     - name: srv-api
       group: destinations
@@ -97,6 +97,9 @@ resources:
       path: ./xs-security-mt.json
       config: # override xsappname as it needs to be unique
         xsappname: bookshop-mt-${org}-${space}
+        oauth2-configuration:
+          redirect-uris:
+          - 'https://*.${default-domain}' # testing only, use custom domain with wildcard for production
   - name: bookshop-mt-service-manager
     type: org.cloudfoundry.managed-service
     parameters:

--- a/mta-single-tenant.yaml
+++ b/mta-single-tenant.yaml
@@ -80,7 +80,7 @@ resources:
         xsappname: bookshop-${org}-${space}
         oauth2-configuration:
           redirect-uris:
-          - ~{app-api/app-url}
+          - ~{app-api/app-url}/**
     requires:
       - name: app-api
   - name: bookshop-hdi-container

--- a/mta-single-tenant.yaml
+++ b/mta-single-tenant.yaml
@@ -63,6 +63,10 @@ modules:
         forwardAuthToken: true
         strictSSL: true
     - name: bookshop-uaa
+    provides:
+      - name: app-api
+        properties:
+          app-url: '${default-url}'
 # --------------------- RESOURCES ---------------------
 resources:
 # -----------------------------------------------------
@@ -74,6 +78,11 @@ resources:
       path: ./xs-security.json
       config: # override xsappname as it needs to be unique
         xsappname: bookshop-${org}-${space}
+        oauth2-configuration:
+          redirect-uris:
+          - ~{app-api/app-url}
+    requires:
+      - name: app-api
   - name: bookshop-hdi-container
     type: org.cloudfoundry.managed-service
     parameters:


### PR DESCRIPTION
This is now mandatory on some landscapes, otherwise login fails.
It is also recommended by XSUAA here: https://help.sap.com/docs/btp/sap-business-technology-platform/security-considerations-for-sap-authorization-and-trust-management-service