### PR TITLE
Remove `pm` dev dependency from sidecar `package.json`

### DIFF
--- a/mtx/sidecar/package.json
+++ b/mtx/sidecar/package.json
@@ -8,8 +8,7 @@
     "passport": "^0"
   },
   "devDependencies": {
-    "sqlite3": "^5",
-    "pm2": "^5.3.0"
+    "sqlite3": "^5"
   },
   "engines": {
     "node": "^16"


### PR DESCRIPTION
Hi @beckermarc, it looks like the `pm` dependency is not used, so it shouldn't be required here.