### PR TITLE
fix: Fix compiler info messages to make the project message-free

### DIFF
--- a/srv/external.cds
+++ b/srv/external.cds
@@ -31,7 +31,7 @@ entity my.bookshop.Addresses as projection on external.A_BusinessPartnerAddress 
   false as tombstone: Boolean
 }
 
-/**
+/*
  * Extend Orders with references to replicated external Addresses
  */
 using { my.bookshop } from '../db/index';

--- a/srv/notes-mashup.cds
+++ b/srv/notes-mashup.cds
@@ -17,7 +17,7 @@ entity my.bookshop.NoteableAddresses as select from API_BUSINESS_PARTNER.A_Busin
   notes
 };
 
-/**
+/*
  * Extend Notes with references to external Addresses.
  */
 using { my.bookshop } from '../db/index';


### PR DESCRIPTION
info messages are hidden by default. If enabled, there is a message about doc-comments not having any effect. `/** */` comments have special meaning in CDS: They contain documentation that is assigned to an artifact as a `doc` property in CSN.  To help users identify places where such a comment has no effect, an info message is provided.

This is just to be 100% message free.