### PR TITLE
Switch from sap_java_buildpack to java_buildpack

### DIFF
--- a/mta.yaml
+++ b/mta.yaml
@@ -13,11 +13,11 @@ modules:
     parameters:
       memory: 1024M
       disk-quota: 512M
-      buildpack: sap_java_buildpack
+      buildpack: java_buildpack
     properties:
         SPRING_PROFILES_ACTIVE: cloud
-        JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jre.SAPMachineJRE']"
-        JBP_CONFIG_SAP_MACHINE_JRE: '{ use_offline_repository: false, version: 17.+ }'
+        JBP_CONFIG_COMPONENTS: '{jres: ["JavaBuildpack::Jre::SapMachineJRE"]}'
+        JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "17.+" } }'
     build-parameters:
       builder: custom
       commands:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "repository": "https://github.com/SAP-samples/cloud-cap-samples-java.git",
     "devDependencies": {
         "@sap/cds-dk": "^7.2",
-        "@cap-js/postgres": "^1.1"
+        "@cap-js/postgres": "~1.2"
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 		<!-- DEPENDENCIES VERSION -->
 		<jdk.version>17</jdk.version>
-		<cds.services.version>2.2.0</cds.services.version>
+		<cds.services.version>2.3.0</cds.services.version>
 		<spring.boot.version>3.1.3</spring.boot.version>
 		<cf-java-logging-support.version>3.7.0</cf-java-logging-support.version>
 	</properties>


### PR DESCRIPTION
We need to switch the Postgres-based sample from the SAP Java Buildpack to the CF one. SAP buildpack does not work with SSL support we delivered in the recent release.