### PR TITLE
Make CDS sample more explicit

### DIFF
--- a/srv/external.cds
+++ b/srv/external.cds
@@ -34,7 +34,7 @@ entity my.bookshop.Addresses as projection on external.A_BusinessPartnerAddress 
 /*
  * Extend Orders with references to replicated external Addresses
  */
-using { my.bookshop } from '../db/index';
-extend bookshop.Orders with {
-  shippingAddress : Association to bookshop.Addresses;
+using { my.bookshop.Orders } from '../db/index';
+extend Orders with {
+  shippingAddress : Association to my.bookshop.Addresses;
 }


### PR DESCRIPTION
The fact that `using { my.bookshop } from '../db/index';` created an implicit alias `bookshop` for the `my.bookshop` package, which is then even used to refer to `my.bookshop.Addresses` as `bookshop.Addresses` (although not even defined in `../db/index`) is not so easy to grasp.

The sample is now more explicit by referring to `my.bookshop.Addresses` and only importing `Orders` from `../db/index`