### PR TITLE
quote the path argument for the cds build command

### DIFF
--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -207,12 +207,12 @@
 						<configuration>
 							<commands>
 								<command>build --for java</command>
-								<command>deploy --to h2 --with-mocks --dry >
-									${project.basedir}/src/main/resources/schema.sql</command>
-								<command>deploy --to h2 --dry >
-									${project.basedir}/src/main/resources/schema-nomocks.sql</command>
-								<command>compile srv/cat-service.cds -2 openapi --openapi:url /api/browse >
-									${project.basedir}/src/main/resources/swagger/openapi.json</command>
+								<command>deploy --to h2 --with-mocks --dry &gt;
+									"${project.basedir}/src/main/resources/schema.sql"</command>
+								<command>deploy --to h2 --dry &gt;
+									"${project.basedir}/src/main/resources/schema-nomocks.sql"</command>
+								<command>compile srv/cat-service.cds -2 openapi --openapi:url /api/browse &gt;
+									"${project.basedir}/src/main/resources/swagger/openapi.json"</command>
 							</commands>
 						</configuration>
 					</execution>


### PR DESCRIPTION
with the prior path argument builds on windows could fail as the path separator was lost along the way. Now the path is quoted and treated as a whole. We tested this on Windows locally and this change fixed the failing build.