### PR TITLE
Use bundled SAPMachine version from sap_java_buildpack

### DIFF
--- a/mta-multi-tenant.yaml
+++ b/mta-multi-tenant.yaml
@@ -18,7 +18,7 @@ modules:
       SPRING_PROFILES_ACTIVE: cloud,sandbox
       CDS_MULTITENANCY_APPUI_TENANTSEPARATOR: "-"
       JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jre.SAPMachineJRE']"
-      JBP_CONFIG_SAP_MACHINE_JRE: '{ use_offline_repository: false, version: 17.+ }'
+      JBP_CONFIG_SAP_MACHINE_JRE: '{ version: 17.+ }'
     build-parameters:
       builder: custom
       commands:

--- a/mta-single-tenant.yaml
+++ b/mta-single-tenant.yaml
@@ -17,7 +17,7 @@ modules:
     properties:
         SPRING_PROFILES_ACTIVE: cloud,sandbox
         JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jre.SAPMachineJRE']"
-        JBP_CONFIG_SAP_MACHINE_JRE: '{ use_offline_repository: false, version: 17.+ }'
+        JBP_CONFIG_SAP_MACHINE_JRE: '{ version: 17.+ }'
     build-parameters:
       builder: custom
       commands:


### PR DESCRIPTION
It seems that we can use the SAPMachine 17 bundled into `sap_java_buildpack`.