### PR TITLE
Generate current model changes into db/changelog/dev

### DIFF
--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -168,6 +168,9 @@
 						<configuration>
 							<commands>
 								<command>build --for java</command>
+								<command>deploy --profile pg --dry --delta-from srv/src/main/resources/db/changelog/v2/model.csn > 
+									srv/src/main/resources/db/changelog/dev/model.sql</command>
+								<command>deploy --model-only --dry > srv/src/main/resources/db/changelog/dev/model.csn</command>
 							</commands>
 						</configuration>
 					</execution>

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -20,11 +20,13 @@ cds:
 ---
 spring:
   config.activate.on-profile: cloud
+  liquibase.contexts: "!dev"
 
 ---
 spring:
   config.activate.on-profile: default
+  liquibase.contexts: "dev"
 cds:
   dataSource:
     auto-config.enabled: false
-    
+

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -3,7 +3,6 @@ my.bookshop.postgresImage: postgres:13
 
 spring:
   web.resources.static-locations: "file:./app"
-  devtools.restart.trigger-file: ".reloadtrigger"
 
 cds:
   dataSource.csv:

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -3,6 +3,7 @@ my.bookshop.postgresImage: postgres:13
 
 spring:
   web.resources.static-locations: "file:./app"
+  devtools.restart.trigger-file: ".reloadtrigger"
 
 cds:
   dataSource.csv:

--- a/srv/src/main/resources/db/changelog/.gitignore
+++ b/srv/src/main/resources/db/changelog/.gitignore
@@ -1,3 +1,5 @@
 !*.sql
 !*.json
-/dev/
+/dev/*.sql
+/dev/*.csn
+/dev/*.json

--- a/srv/src/main/resources/db/changelog/.gitignore
+++ b/srv/src/main/resources/db/changelog/.gitignore
@@ -1,2 +1,3 @@
 !*.sql
 !*.json
+/dev/

--- a/srv/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/srv/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -16,6 +16,7 @@ databaseChangeLog:
   - changeSet:
       id: "development"
       author: CAP Java
+      context: dev
       changes:
         - sqlFile:
             dbms: postgresql

--- a/srv/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/srv/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -14,7 +14,7 @@ databaseChangeLog:
             dbms: postgresql
             path: db/changelog/v2/model.sql
   - changeSet:
-      id: "current development"
+      id: "development"
       author: CAP Java
       changes:
         - sqlFile:

--- a/srv/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/srv/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -13,3 +13,10 @@ databaseChangeLog:
         - sqlFile:
             dbms: postgresql
             path: db/changelog/v2/model.sql
+  - changeSet:
+      id: "current development"
+      author: CAP Java
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: db/changelog/dev/model.sql

--- a/srv/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/srv/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -16,7 +16,7 @@ databaseChangeLog:
   - changeSet:
       id: "development"
       author: CAP Java
-      context: dev
+      contextFilter: dev
       changes:
         - sqlFile:
             dbms: postgresql

--- a/srv/src/test/java/my/bookshop/config/DatabaseConfiguration.java
+++ b/srv/src/test/java/my/bookshop/config/DatabaseConfiguration.java
@@ -3,7 +3,6 @@ package my.bookshop.config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.devtools.restart.RestartScope;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,7 +16,6 @@ public class DatabaseConfiguration {
 
 	@Bean
 	@ServiceConnection
-	@RestartScope
 	PostgreSQLContainer<?> postgresContainer(@Value("${my.bookshop.postgres-image}") String imageName) {
 		DockerImageName image = DockerImageName.parse(imageName).asCompatibleSubstituteFor(POSTGRES);
 		return new PostgreSQLContainer<>(image)

--- a/srv/src/test/resources/application.yaml
+++ b/srv/src/test/resources/application.yaml
@@ -1,5 +1,0 @@
----
-my.bookshop.postgresImage: postgres:13
-
-spring:
-  liquibase.contexts: dev

--- a/srv/src/test/resources/application.yaml
+++ b/srv/src/test/resources/application.yaml
@@ -1,0 +1,5 @@
+---
+my.bookshop.postgresImage: postgres:13
+
+spring:
+  liquibase.contexts: dev


### PR DESCRIPTION
With this PR the following changes are made:
- Also generate a delta DDL sql for current model changes against model v2.
- Also deploy current CDS development model as delta DDL sql to Postgres with Liquibase
- Ensure that the Postgres testcontainer instance is also restarted to avoid Liquibase issue due to modified changeset context for current dev DDL sql.