### PR TITLE
Simplify `.cdsrc.json`

### DIFF
--- a/.cdsrc.json
+++ b/.cdsrc.json
@@ -4,11 +4,5 @@
         "extensibility": true,
         "toggles": true
     },
-    "build": {
-        "target": "."
-    },
-    "profiles": [
-        "with-mtx-sidecar",
-        "java"
-    ]
+    "profile": "with-mtx-sidecar"
 }

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ For single tenant deployment, replace the `requires` section in _`.cdsrc.json`_ 
     },
 ```
 
-**In addition** remove `with-mtx-sidecar` from `profiles` in `.cdsrc.json` and delete the `mtx` folder in root.
+**In addition** remove `profile: "with-mtx-sidecar"` from `.cdsrc.json` and delete the `mtx` folder in root.
 
 For multi tenant deployment, replace the `requires` section in _`.cdsrc.json`_ with:
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ For single tenant deployment, replace the `requires` section in _`.cdsrc.json`_ 
     },
 ```
 
-**In addition** remove `profile: "with-mtx-sidecar"` from `.cdsrc.json` and delete the `mtx` folder in root.
+**In addition** remove `"profile": "with-mtx-sidecar"` from `.cdsrc.json` and delete the `mtx` folder in root.
 
 For multi tenant deployment, replace the `requires` section in _`.cdsrc.json`_ with:
 


### PR DESCRIPTION
With CDS 7…

- The `target: "."` is automatically coming with profile `java`
- The `java` profile is auto-assigned if a `pom.xml` is found

→ We can simplify the config here even further

@beckermarc 