### PR TITLE
Version bump build plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.10.1</version>
+				<version>3.11.0</version>
 				<configuration>
 					<release>${jdk.version}</release>
 					<encoding>UTF-8</encoding>
@@ -86,7 +86,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>flatten-maven-plugin</artifactId>
-				<version>1.4.1</version>
+				<version>1.5.0</version>
 				<configuration>
 					<updatePomFile>true</updatePomFile>
 					<flattenMode>resolveCiFriendliesOnly</flattenMode>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M9</version>
+				<version>3.2.2</version>
 				<configuration>
 					<failIfNoTests>true</failIfNoTests>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
 						<configuration>
 							<rules>
 								<requireMavenVersion>
-									<version>3.5</version>
+									<version>3.6</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
 									<version>${jdk.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>flatten-maven-plugin</artifactId>
-				<version>1.3.0</version>
+				<version>1.4.1</version>
 				<configuration>
 					<updatePomFile>true</updatePomFile>
 					<flattenMode>resolveCiFriendliesOnly</flattenMode>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.2.1</version>
+				<version>3.4.1</version>
 				<executions>
 					<execution>
 						<id>Project Structure Checks</id>
@@ -123,7 +123,7 @@
 						<configuration>
 							<rules>
 								<requireMavenVersion>
-									<version>3.6</version>
+									<version>3.5.4</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
 									<version>${jdk.version}</version>


### PR DESCRIPTION
This PR updates all outdated maven build plugins. One update also requires the minimum maven version 3.5.4, which is already very old.