### PR TITLE
downgrade @sap/hdi-deploy due to bug in 4.9.0

### DIFF
--- a/db/package.json
+++ b/db/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deploy",
   "dependencies": {
-    "@sap/hdi-deploy": "^4"
+    "@sap/hdi-deploy": "4.8.2"
   },
   "engines": {
     "node": "^18"

--- a/mtx/sidecar/package.json
+++ b/mtx/sidecar/package.json
@@ -5,7 +5,8 @@
     "@sap/xssec": "^3",
     "express": "^4",
     "hdb": "^0",
-    "passport": "^0"
+    "passport": "^0",
+    "@sap/hdi-deploy": "4.8.2"
   },
   "devDependencies": {
     "sqlite3": "^5",


### PR DESCRIPTION
@hdi-deployer in version 4.9.0 has an issue:

Error: Cannot find module 'core-util-is'

Version 4.8.2 is fine. Hence, we temporarily downgrade