### PR TITLE
Use HEX mode on SAP HANA

### DIFF
--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -48,6 +48,7 @@ spring:
   config.activate.on-profile: cloud
   sql.init.schema-locations: "classpath:schema-nomocks.sql"
 cds:
+  sql.hana.optimizationMode: hex
   messaging.services:
     bupa-messaging:
       kind: enterprise-messaging


### PR DESCRIPTION
On SAP HANA use the [SQL Optimization Mode](https://cap.cloud.sap/docs/java/persistence-services#sql-optimization-mode) `hex`.