### PR TITLE
Switch to Jakarta buildpack

### DIFF
--- a/mta-multi-tenant.yaml
+++ b/mta-multi-tenant.yaml
@@ -13,7 +13,7 @@ modules:
     parameters:
       memory: 1024M
       disk-quota: 512M
-      buildpack: sap_java_buildpack
+      buildpack: sap_java_buildpack_jakarta
     properties:
       SPRING_PROFILES_ACTIVE: cloud,sandbox
       CDS_MULTITENANCY_APPUI_TENANTSEPARATOR: "-"

--- a/mta-single-tenant.yaml
+++ b/mta-single-tenant.yaml
@@ -13,7 +13,7 @@ modules:
     parameters:
       memory: 1024M
       disk-quota: 512M
-      buildpack: sap_java_buildpack
+      buildpack: sap_java_buildpack_jakarta
     properties:
         SPRING_PROFILES_ACTIVE: cloud,sandbox
         JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jre.SAPMachineJRE']"


### PR DESCRIPTION
Replaces the old buildpack with new one.

See https://community.sap.com/t5/technology-blogs-by-sap/sap-java-buildpack-2-jakarta-based-fresh-and-new/ba-p/13619580