### PR TITLE
Suppress setting spring.datasource.url by cf_env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ package-lock.json
 .mta/
 *.mtar
 mta.yaml
+mta_archives/
 
 *.log*
 gc_history*

--- a/mta.yaml
+++ b/mta.yaml
@@ -18,11 +18,11 @@ modules:
         SPRING_PROFILES_ACTIVE: cloud
         JBP_CONFIG_COMPONENTS: '{jres: ["JavaBuildpack::Jre::SapMachineJRE"]}'
         JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "17.+" } }'
-        # The Java CF Env library is added to the classpath by the java_buildpack on application start.
-        # CF Env detects the PostgreSQL binding and sets the property spring.datasource.url, but this
-        # disables the CDS datasource auto-configuration and the CAP Java PostgreSQL datasource is not set up.
-        # The next option disables CF Env and makes the PostgreSQL datasource provided by CAP Java work.
-        JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
+        # We need datasource to be configured by CAP, not by cfenv
+        # cfenv uses names of the services, so this variable must be adapted if needed
+        # as CFENV_SERVICE_[service-name]_ENABLED
+        # See https://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections.html
+        CFENV_SERVICE_BOOKSHOP-PG-DB_ENABLED: false
     build-parameters:
       builder: custom
       commands:

--- a/mta.yaml
+++ b/mta.yaml
@@ -18,7 +18,7 @@ modules:
         SPRING_PROFILES_ACTIVE: cloud
         JBP_CONFIG_COMPONENTS: '{jres: ["JavaBuildpack::Jre::SapMachineJRE"]}'
         JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "17.+" } }'
-        # We need datasource to be configured by CAP, not by cfenv
+        # We do not want cfenv to configure the DataSource for us
         # cfenv uses names of the services, so this variable must be adapted if needed
         # as CFENV_SERVICE_[service-name]_ENABLED
         # See https://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections.html

--- a/mta.yaml
+++ b/mta.yaml
@@ -18,6 +18,8 @@ modules:
         SPRING_PROFILES_ACTIVE: cloud
         JBP_CONFIG_COMPONENTS: '{jres: ["JavaBuildpack::Jre::SapMachineJRE"]}'
         JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "17.+" } }'
+        # disable auto-reconfiguration with cf-env
+        JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
     build-parameters:
       builder: custom
       commands:

--- a/mta.yaml
+++ b/mta.yaml
@@ -18,7 +18,7 @@ modules:
         SPRING_PROFILES_ACTIVE: cloud
         JBP_CONFIG_COMPONENTS: '{jres: ["JavaBuildpack::Jre::SapMachineJRE"]}'
         JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "17.+" } }'
-        # disable auto-reconfiguration with cf-env
+        # disable auto-reconfiguration of cf-env
         JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
     build-parameters:
       builder: custom

--- a/mta.yaml
+++ b/mta.yaml
@@ -18,10 +18,10 @@ modules:
         SPRING_PROFILES_ACTIVE: cloud
         JBP_CONFIG_COMPONENTS: '{jres: ["JavaBuildpack::Jre::SapMachineJRE"]}'
         JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "17.+" } }'
-        # The library Java CF Env is added to the classpath by the java_buildpack on startup.
-        # CF Env detects the PostegreSQL binding and sets the property spring.datasource.url, but this
-        # disables the CDS datasource auto-configuration and the PostgreSQL datasource of CAP Java is not setup.
-        # The next option disables CF Env and makes the PostgreSQL datasource provided by CAP Java working.
+        # The Java CF Env library is added to the classpath by the java_buildpack on application start.
+        # CF Env detects the PostgreSQL binding and sets the property spring.datasource.url, but this
+        # disables the CDS datasource auto-configuration and the CAP Java PostgreSQL datasource is not set up.
+        # The next option disables CF Env and makes the PostgreSQL datasource provided by CAP Java work.
         JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
     build-parameters:
       builder: custom

--- a/mta.yaml
+++ b/mta.yaml
@@ -18,7 +18,10 @@ modules:
         SPRING_PROFILES_ACTIVE: cloud
         JBP_CONFIG_COMPONENTS: '{jres: ["JavaBuildpack::Jre::SapMachineJRE"]}'
         JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "17.+" } }'
-        # disable auto-reconfiguration of cf-env
+        # The library Java CF Env is added to the classpath by the java_buildpack on startup.
+        # CF Env detects the PostegreSQL binding and sets the property spring.datasource.url, but this
+        # disables the CDS datasource auto-configuration and the PostgreSQL datasource of CAP Java is not setup.
+        # The next option disables CF Env and makes the PostgreSQL datasource provided by CAP Java working.
         JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
     build-parameters:
       builder: custom

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -1,10 +1,6 @@
 ---
 my.bookshop.postgresImage: postgres:14
 
-cfenv.service:
-  '[bookshop-pg-db]':
-    enabled: false
-
 cds:
   dataSource.csv:
     initializationMode: always

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -1,6 +1,10 @@
 ---
 my.bookshop.postgresImage: postgres:14
 
+cfenv.service:
+  '[bookshop-pg-db]':
+    enabled: false
+
 cds:
   dataSource.csv:
     initializationMode: always


### PR DESCRIPTION
The library [Java CF Env](https://github.com/pivotal-cf/java-cfenv/tree/main/java-cfenv-boot) is added to the classpath by the java_buildpack on startup:

```
   2024-05-17T14:13:47.36+0200 [STG/0] OUT -----> Downloading Java Cf Env 3.1.5 from https://java-buildpack.cloudfoundry.org/java-cfenv/java-cfenv-3.1.5.jar (found in cache)
```

cf_env detects the PostegreSQL binding and already sets the property `spring.datasource.url`:

```
{"msg":"Setting spring.datasource properties from bound service [bookshop-pg-db]","level":"INFO","written_ts":"1715940082155066735","logger":"io.pivotal.cfenv.spring.boot.CfDataSourceEnvironmentPostProcessor","written_at":"2024-05-17T10:01:22.155Z","thread":"main","type":"log"}
```

This disables the CDS datasource autoconfig and the PG datasource `PostgreSqlDataSourceDescriptor` is not initialized:

```
Found 'spring.datasource.url' configuration: Auto-configuration of DataSource beans is disabled.","level":"INFO","written_ts":"1715940082974390167","logger":"com.sap.cds.framework.spring.config.runtime.CdsRuntimeBeanDefinitionRegistrar"
```

The env. variable `JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'` disables the cf_env and this behaviour. Further details can be found here: https://github.com/pivotal-cf/java-cfenv?tab=readme-ov-file#pushing-your-application-to-cloud-foundry

I tried also this approach: https://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections.html
```
If you need to prevent processing of a specific service instance, set the flag in your application properties to:
cfenv.service.{serviceName}.enabled=false
```
But I didn't get this approach working.