### PR TITLE
Move `cfenv` switch for PostgreSQL  to `application yaml`

### DIFF
--- a/mta.yaml
+++ b/mta.yaml
@@ -18,11 +18,6 @@ modules:
         SPRING_PROFILES_ACTIVE: cloud
         JBP_CONFIG_COMPONENTS: '{jres: ["JavaBuildpack::Jre::SapMachineJRE"]}'
         JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "17.+" } }'
-        # We do not want cfenv to configure the DataSource for us
-        # cfenv uses names of the services, so this variable must be adapted if needed
-        # as CFENV_SERVICE_[service-name]_ENABLED
-        # See https://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections.html
-        CFENV_SERVICE_BOOKSHOP-PG-DB_ENABLED: false
     build-parameters:
       builder: custom
       commands:

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -19,6 +19,11 @@ spring:
   config.activate.on-profile: cloud
   liquibase.contexts: "!dev"
 
+# This prevents the cfenv library from configuring Spring DataSource for Postgres instance
+# which can cause problems with TLS configurations on hyperscalers
+# Format: cfenv.service.<postgres-instance-name>.enabled: false
+# See https://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections.html
+cfenv.service.bookshop-pg-db.enabled: false
 ---
 spring:
   config.activate.on-profile: default


### PR DESCRIPTION
Perhaps, `application.yaml` is a better place for the switch in question. 