### PR TITLE
doc(README): Mention that there are default mock users for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Make sure you have set up a development environment (that means, you’ve instal
 
 You'll start with a predefined stock of books as this procedure starts the bookshop application with a CSV-initialized in-memory H2 database.
 
-Two [additional mock users](https://cap.cloud.sap/docs/java/security#preconfigured-mock-users)
+Two mock users in addition to the [default mock users](https://cap.cloud.sap/docs/java/security#preconfigured-mock-users)
 are defined for local development:
 - User: `user`, password: `user` to browse books
 - User: `admin`, password: `admin` to manage books and orders

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ Make sure you have set up a development environment (that means, you’ve instal
 
 You'll start with a predefined stock of books as this procedure starts the bookshop application with a CSV-initialized in-memory H2 database.
 
-Two mock users are defined for local development:
+Two [additional mock users](https://cap.cloud.sap/docs/java/security#preconfigured-mock-users)
+are defined for local development:
 - User: `user`, password: `user` to browse books
 - User: `admin`, password: `admin` to manage books and orders
 


### PR DESCRIPTION
The log after running `mvn clean spring-boot:run` says:

```
INFO 36234 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : Added mock user {"name":"privileged","password":"","systemUser":false,"privileged":true,"internalUser":false,"roles":[],"attributes":{},"unrestricted":[],"additional":{},"valid":true}
INFO 36234 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : Added mock user {"name":"authenticated","password":"","systemUser":false,"privileged":false,"internalUser":false,"roles":[],"attributes":{},"unrestricted":[],"additional":{},"valid":true}
INFO 36234 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : Added mock user {"name":"admin","password":"admin","systemUser":false,"privileged":false,"internalUser":false,"roles":["admin"],"attributes":{"businessPartner":["10401010"]},"unrestricted":[],"additional":{},"valid":true}
INFO 36234 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : Added mock user {"name":"internal","password":"","systemUser":false,"privileged":false,"internalUser":true,"roles":[],"attributes":{},"unrestricted":[],"additional":{},"valid":true}
INFO 36234 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : Added mock user {"name":"system","password":"","systemUser":true,"privileged":false,"internalUser":false,"roles":[],"attributes":{},"unrestricted":[],"additional":{},"valid":true}
INFO 36234 --- [  restartedMain] c.s.c.f.s.c.a.m.MockUsersSecurityConfig  : Added mock user {"name":"user","password":"user","systemUser":false,"privileged":false,"internalUser":false,"roles":[],"attributes":{},"unrestricted":[],"additional":{},"valid":true}
```

Also the documentation states that there are users `authenticated` and others.  These work when running the app locally.