### PR TITLE
doc(README): Make shell snippet copy&paste safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Use the following steps to import the project to Eclipse:
 
 	```${workspace_loc:bookshop-parent}```
 
-	Afterwards, click **Run**. This step starts the applications `main` method located in `src/main/java/my/bookshop/Application.java`.
+	Afterward, click **Run**. This step starts the applications `main` method located in `src/main/java/my/bookshop/Application.java`.
 
 ## Using IntelliJ Idea (Community and Ultimate)
 
@@ -447,7 +447,7 @@ mvn clean package -DskipTests=true
 ```
 
 ```bash
-pack build $YOUR_CONTAINER_REGISTRY/bookshop-srv \
+pack build ${YOUR_CONTAINER_REGISTRY:?}/bookshop-srv \
         --path srv/target/*-exec.jar \
         --buildpack gcr.io/paketo-buildpacks/sap-machine \
         --buildpack gcr.io/paketo-buildpacks/java \
@@ -456,12 +456,12 @@ pack build $YOUR_CONTAINER_REGISTRY/bookshop-srv \
         --env BP_JVM_VERSION=17
 ```
 
-(Replace `$YOUR_CONTAINER_REGISTRY` with the full-qualified hostname of your container registry)
+(Replace `${YOUR_CONTAINER_REGISTRY:?}` with the full-qualified hostname of your container registry)
 
 **Build Approuter Image:**
 
 ```bash
-pack build $YOUR_CONTAINER_REGISTRY/bookshop-approuter \
+pack build ${YOUR_CONTAINER_REGISTRY:?}/bookshop-approuter \
      --path app \
      --buildpack gcr.io/paketo-buildpacks/nodejs \
      --builder paketobuildpacks/builder-jammy-base \
@@ -471,7 +471,7 @@ pack build $YOUR_CONTAINER_REGISTRY/bookshop-approuter \
 **Build database deployer image (single tenant only):**
 
 ```bash
-pack build $YOUR_CONTAINER_REGISTRY/bookshop-hana-deployer \
+pack build ${YOUR_CONTAINER_REGISTRY:?}/bookshop-hana-deployer \
      --path db \
      --buildpack gcr.io/paketo-buildpacks/nodejs \
      --builder paketobuildpacks/builder-jammy-base \
@@ -481,7 +481,7 @@ pack build $YOUR_CONTAINER_REGISTRY/bookshop-hana-deployer \
 **Build sidecar image (multi tenant only):**
 
 ```bash
-pack build $YOUR_CONTAINER_REGISTRY/bookshop-sidecar \
+pack build ${YOUR_CONTAINER_REGISTRY:?}/bookshop-sidecar \
      --path mtx/sidecar/gen \
      --buildpack gcr.io/paketo-buildpacks/nodejs \
      --builder paketobuildpacks/builder-jammy-base \
@@ -493,21 +493,21 @@ pack build $YOUR_CONTAINER_REGISTRY/bookshop-sidecar \
 You can push all the container images to your container registry, using:
 
 ```bash
-docker push $YOUR_CONTAINER_REGISTRY/bookshop-srv
+docker push ${YOUR_CONTAINER_REGISTRY:?}/bookshop-srv
 
-docker push $YOUR_CONTAINER_REGISTRY/bookshop-approuter
+docker push ${YOUR_CONTAINER_REGISTRY:?}/bookshop-approuter
 ```
 
 #### Single Tenant
 
 ```bash
-docker push $YOUR_CONTAINER_REGISTRY/bookshop-hana-deployer
+docker push ${YOUR_CONTAINER_REGISTRY:?}/bookshop-hana-deployer
 ```
 
 #### Multi Tenant
 
 ```bash
-docker push $YOUR_CONTAINER_REGISTRY/bookshop-sidecar
+docker push ${YOUR_CONTAINER_REGISTRY:?}/bookshop-sidecar
 ```
 
 ### Configuration


### PR DESCRIPTION
Many bash/shell snippets in the README use an environment variable `YOUR_CONTAINER_REGISTRY`, which is used as `$YOUR_CONTAINER_REGISTRY`.

However, that has the downside that if users copy & paste the snippet and accidentally press enter or use a shell that doesn't allow multi- line pasting (and executes it immediately), then the variable will be replaced by an empty string, because it wasn't set before.

It's good practice to make those snippets copy&paste-safe. We can achieve that by adding `:?` to the variable, which emits an error if the variable is unset or null.

See https://devhints.io/bash for a bash cheat sheet.

Example:

```sh
docker push ${YOUR_CONTAINER_REGISTRY:?}/bookshop-srv
```

On ZSH:

```
zsh: YOUR_CONTAINER_REGISTRY: parameter not set
```

On Bash:

```
bash: YOUR_CONTAINER_REGISTRY: parameter null or not set
```