### PR TITLE
Add devDependency to @sap/cds@^7 to avoid using @sap/cds@8

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "license": "Apache License Version 2.0",
     "repository": "https://github.com/SAP-samples/cloud-cap-samples-java.git",
     "devDependencies": {
-        "@cap-js/postgres": "^1"
+        "@cap-js/postgres": "^1",
+        "@sap/cds": "^7"
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,9 @@
 		<cds.services.version>2.10.1</cds.services.version>
 		<spring.boot.version>3.2.6</spring.boot.version>
 		<cf-java-logging-support.version>3.8.3</cf-java-logging-support.version>
+
 		<cds.cdsdk-version>7.9.4</cds.cdsdk-version>
+
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,7 @@
 		<cds.services.version>2.10.1</cds.services.version>
 		<spring.boot.version>3.2.6</spring.boot.version>
 		<cf-java-logging-support.version>3.8.3</cf-java-logging-support.version>
-
 		<cds.cdsdk-version>7.9.4</cds.cdsdk-version>
-
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 


### PR DESCRIPTION
`@cap-js/postgres` has an open dependency to cds-dk and cds:
"@sap/cds": ">=7.6", "@sap/cds-dk": ">=7.5"

This causes the usage of cds-dk 7 with cds 8, which is incompatible.
