### PR TITLE
Use java profile in MTX sidecar

### DIFF
--- a/mtx/sidecar/package.json
+++ b/mtx/sidecar/package.json
@@ -15,12 +15,9 @@
     "node": "^18"
   },
   "cds": {
-    "profile": "mtx-sidecar",
+    "profiles": ["mtx-sidecar", "java"],
     "[development]": {
       "requires": { "auth": "dummy" }
-    },
-    "cdsc": {
-      "moduleLookupDirectories": [ "node_modules/", "target/cds/" ]
     }
   },
   "scripts": {


### PR DESCRIPTION
Ensures that reuse models in target/cds/ folders are respected.