### PR TITLE
Added test scope to dependency my:bookshop

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,6 +22,7 @@
 			<groupId>my</groupId>
 			<artifactId>bookshop</artifactId>
 			<version>${revision}</version>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Fixes warning:
```
[WARNING] The following dependencies could not be resolved at this point of the build but seem to be part of the reactor:
[WARNING] o my:bookshop:jar:1.0.0-SNAPSHOT (compile)
[WARNING] Try running the build up to the lifecycle phase "package"
 ```