### PR TITLE
Upgrade all components to cds8

### DIFF
--- a/db/package.json
+++ b/db/package.json
@@ -1,7 +1,8 @@
 {
   "name": "deploy",
   "dependencies": {
-    "@sap/hdi-deploy": "^5"
+    "@sap/hdi-deploy": "^5",
+    "@cap-js/hana": "^1"
   },
   "engines": {
     "node": "^18"

--- a/db/package.json
+++ b/db/package.json
@@ -5,7 +5,7 @@
     "@sap/hdi-deploy": "^5"
   },
   "engines": {
-    "node": "^18 || ^20"
+    "node": "^20"
   },
   "scripts": {
     "start": "node node_modules/@sap/hdi-deploy/deploy.js --use-hdb",

--- a/db/package.json
+++ b/db/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deploy",
   "dependencies": {
-    "@sap/hdi-deploy": "4.8.2"
+    "@sap/hdi-deploy": "^5"
   },
   "engines": {
     "node": "^18"

--- a/db/package.json
+++ b/db/package.json
@@ -1,14 +1,14 @@
 {
   "name": "deploy",
   "dependencies": {
-    "@sap/hdi-deploy": "^5",
-    "@cap-js/hana": "^1"
+    "hdb": "^0",
+    "@sap/hdi-deploy": "^5"
   },
   "engines": {
-    "node": "^18"
+    "node": "^18 || ^20"
   },
   "scripts": {
-    "start": "node node_modules/@sap/hdi-deploy/deploy.js",
+    "start": "node node_modules/@sap/hdi-deploy/deploy.js --use-hdb",
     "build": "npm i && npx cds build .. --for hana --production"
   }
 }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -123,6 +123,9 @@
 				</executions>
 				<configuration>
 					<executable>${cds.npm.executable}</executable>
+					<environmentVariables>
+						<PATH>${cds.node.directory}${path.separator}${env.PATH}</PATH>
+					</environmentVariables>
 					<skip>${skipTests}</skip>
 					<workingDirectory>${sidecar.dir}</workingDirectory>
 					<async>true</async>

--- a/mtx/sidecar/package.json
+++ b/mtx/sidecar/package.json
@@ -1,12 +1,13 @@
 {
   "dependencies": {
     "@sap/cds": "^7",
-    "@sap/cds-mtxs": "^1",
+    "@sap/cds-mtxs": "^2",
     "@sap/xssec": "^3",
     "express": "^4",
     "hdb": "^0",
     "passport": "^0",
-    "@sap/hdi-deploy": "^5"
+    "@sap/hdi-deploy": "^5",
+    "@cap-js/hana": "^1"
   },
   "devDependencies": {
     "sqlite3": "^5"

--- a/mtx/sidecar/package.json
+++ b/mtx/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@sap/cds": "^7",
+    "@sap/cds": "^8",
     "@sap/cds-mtxs": "^2",
     "@sap/xssec": "^3",
     "express": "^4",

--- a/mtx/sidecar/package.json
+++ b/mtx/sidecar/package.json
@@ -1,19 +1,16 @@
 {
   "dependencies": {
+    "@cap-js/hana": "^1",
     "@sap/cds": "^8",
     "@sap/cds-mtxs": "^2",
-    "@sap/xssec": "^3",
-    "express": "^4",
-    "hdb": "^0",
-    "passport": "^0",
-    "@sap/hdi-deploy": "^5",
-    "@cap-js/hana": "^1"
+    "@sap/xssec": "^4",
+    "express": "^4"
   },
   "devDependencies": {
-    "sqlite3": "^5"
+    "@cap-js/sqlite": "^1"
   },
   "engines": {
-    "node": "^18"
+    "node": "^18 || ^20"
   },
   "cds": {
     "profiles": ["mtx-sidecar", "java"],

--- a/mtx/sidecar/package.json
+++ b/mtx/sidecar/package.json
@@ -10,7 +10,7 @@
     "@cap-js/sqlite": "^1"
   },
   "engines": {
-    "node": "^18 || ^20"
+    "node": "^20"
   },
   "cds": {
     "profiles": ["mtx-sidecar", "java"],

--- a/mtx/sidecar/package.json
+++ b/mtx/sidecar/package.json
@@ -6,7 +6,7 @@
     "express": "^4",
     "hdb": "^0",
     "passport": "^0",
-    "@sap/hdi-deploy": "4.8.2"
+    "@sap/hdi-deploy": "^5"
   },
   "devDependencies": {
     "sqlite3": "^5"

--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -192,7 +192,7 @@
 							<goal>npm</goal>
 						</goals>
 						<configuration>
-							<arguments>install @sap/cds-dk@${cds.install-cdsdk.version} @sap/cds-mtxs@^2 --no-save</arguments>
+							<arguments>install @sap/cds-dk@${cds.install-cdsdk.version} @sap/cds-mtxs@^2 @cap-js/hana@^1 --no-save</arguments>
 						</configuration>
 					</execution>
 

--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -192,7 +192,7 @@
 							<goal>npm</goal>
 						</goals>
 						<configuration>
-							<arguments>install @sap/cds-dk@${cds.install-cdsdk.version} @sap/cds-mtxs@^2 @cap-js/hana@^1 --no-save</arguments>
+							<arguments>install @sap/cds-dk@${cds.install-cdsdk.version} @sap/cds-mtxs@^2 --ignore-scripts --no-save</arguments>
 						</configuration>
 					</execution>
 

--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -192,7 +192,7 @@
 							<goal>npm</goal>
 						</goals>
 						<configuration>
-							<arguments>install @sap/cds-dk@${cds.install-cdsdk.version} @sap/cds-mtxs@^2 @cap-js/hana@^1 --no-save</arguments>
+							<arguments>install @sap/cds-dk@${cds.install-cdsdk.version} @sap/cds-mtxs@^2 --no-save</arguments>
 						</configuration>
 					</execution>
 

--- a/srv/src/main/resources/application.yaml
+++ b/srv/src/main/resources/application.yaml
@@ -9,6 +9,7 @@ cds:
   odata-v4:
     endpoint.path: "/api"
   security:
+    authentication.normalize-provider-tenant: true
     mock.users:
       admin:
         password: admin


### PR DESCRIPTION
This PR fixes test failures of the Bookshop ITests using CAP 3 and cds8.

* `authentication.normalize-provider-tenant: true` needs to be set in the `application.yaml` because current itest logic requires the provider tenant to be subscribed. The deployment shell script is setting this value to `false` using a `sed` command which requires this property to be available in the file
* `hdi-deploy` in version `5` does not bundle any hana db client, but comes with a post install script that checks that one client has been installed by an external party. As we don´t need db accesses in the ìnstall-dependencies` goal in `pom.xml`, we just set `--ignore-scripts` 