### PR TITLE
Revert "Use expression annotations in @restrict"

### DIFF
--- a/srv/review-service.cds
+++ b/srv/review-service.cds
@@ -18,7 +18,7 @@ service ReviewService {
         {
             grant : '*',
             to : 'authenticated-user',
-            where : (createdBy=$user)
+            where : 'createdBy=$user'
         },
         {
             grant : '*',


### PR DESCRIPTION
Reverts SAP-samples/cloud-cap-samples-java#328. 
Causes issues in native image build that need additional investigation.