### PR TITLE
Use sapmachine for maven build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,6 +25,6 @@ jobs:
       uses: actions/setup-java@v4
       with:
         java-version: 17
-        distribution: 'temurin'
+        distribution: 'sapmachine'
     - name: Build with Maven
       run: mvn -ntp -B clean install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: 21
         distribution: 'sapmachine'
     - name: Build with Maven
       run: mvn -ntp -B clean install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 21
+        java-version: 17
         distribution: 'sapmachine'
     - name: Build with Maven
       run: mvn -ntp -B clean install


### PR DESCRIPTION
With [latest version](https://github.com/actions/setup-java/releases/tag/v4.3.0) the github action actions/setup-java supports installing sapmachine :-)
I think we should advertise our Java VM in our projects.