### PR TITLE
Build with Java 21

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: 21
         distribution: 'sapmachine'
     - name: Build with Maven
       run: mvn -ntp -B clean install

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The following sections describe how to set up, build, and run the project.
 ## Prerequisites
 
 Make sure you have set up a development environment (that means, you’ve installed the CDS Compiler, Java 21, and Apache Maven) [as described here](https://cap.cloud.sap/docs/java/getting-started).
-This sample application requires a Java 21 compatible JDK, unlike the CAP Java SDK itself. We recommend using SAPMachine version 21, which can be downloaded  [here](https://sap.github.io/SapMachine/).
+This sample application requires a Java 21 compatible JDK, unlike the CAP Java SDK itself. We recommend using SapMachine version 21, which can be downloaded  [here](https://sap.github.io/SapMachine/).
 
 ## Clone Build & Run
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The following sections describe how to set up, build, and run the project.
 ## Prerequisites
 
 Make sure you have set up a development environment (that means, you’ve installed the CDS Compiler, Java 21, and Apache Maven) [as described here](https://cap.cloud.sap/docs/java/getting-started).
-This sample application requires a Java 21 compatible JDK, unlike the CAP Java SDK itself. We recommend using SapMachine version 21, which can be downloaded  [here](https://sap.github.io/SapMachine/).
+This sample application requires a Java 21 compatible JDK. We recommend using [SapMachine 21](https://sap.github.io/SapMachine/).
 
 ## Clone Build & Run
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ The following sections describe how to set up, build, and run the project.
 
 ## Prerequisites
 
-Make sure you have set up a development environment (that means, you’ve installed the CDS Compiler, Java, and Apache Maven) [as described here](https://cap.cloud.sap/docs/java/getting-started).
+Make sure you have set up a development environment (that means, you’ve installed the CDS Compiler, Java 21, and Apache Maven) [as described here](https://cap.cloud.sap/docs/java/getting-started).
+This sample application requires a Java 21 compatible JDK, unlike the CAP Java SDK itself. We recommend using SAPMachine version 21, which can be downloaded  [here](https://sap.github.io/SapMachine/).
 
 ## Clone Build & Run
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -49,7 +49,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.2.5</version>
+				<version>3.5.0</version>
 				<configuration>
 					<failIfNoTests>false</failIfNoTests>
 				</configuration>
@@ -67,7 +67,7 @@
 				<!-- Tests ending with *IT.java will be executed here -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.2.5</version>
+				<version>3.5.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -108,7 +108,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.4.1</version>
 				<executions>
 					<execution>
 						<phase>pre-integration-test</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.12.1</version>
+				<version>3.13.0</version>
 				<configuration>
 					<release>${jdk.version}</release>
 					<encoding>UTF-8</encoding>
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.2.5</version>
+				<version>3.5.0</version>
 				<configuration>
 					<failIfNoTests>true</failIfNoTests>
 				</configuration>
@@ -109,7 +109,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.2.5</version>
+				<version>3.5.0</version>
 			</plugin>
 
 			<!-- POM FLATTENING FOR CI FRIENDLY VERSIONS -->
@@ -143,7 +143,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.4.1</version>
+				<version>3.5.0</version>
 				<executions>
 					<execution>
 						<id>Project Structure Checks</id>
@@ -153,7 +153,7 @@
 						<configuration>
 							<rules>
 								<requireMavenVersion>
-									<version>3.5</version>
+									<version>3.6.3</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
 									<version>${jdk.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
 		<revision>1.0.0-SNAPSHOT</revision>
 
 		<!-- DEPENDENCIES VERSION -->
-		<jdk.version>17</jdk.version>
+		<jdk.version>21</jdk.version>
 		<cds.services.version>3.2.0</cds.services.version>
 		<cloud.sdk.version>5.11.0</cloud.sdk.version>
 		<xsuaa.version>3.5.3</xsuaa.version>
 		<cf-java-logging-support.version>3.8.4</cf-java-logging-support.version>
-		<cds.cdsdk-version>8.2.0</cds.cdsdk-version>
+		<cds.cdsdk-version>8.2.1</cds.cdsdk-version>
 	</properties>
 
 	<modules>

--- a/srv/src/main/java/my/bookshop/handlers/AdminServiceAddressHandler.java
+++ b/srv/src/main/java/my/bookshop/handlers/AdminServiceAddressHandler.java
@@ -140,7 +140,7 @@ public class AdminServiceAddressHandler implements EventHandler {
 					.filter(ext -> ext.getId().equals(rep.getId()))
 					.findFirst();
 
-				if(!matching.isPresent()) {
+				if(matching.isEmpty()) {
 					rep.setTombstone(true);
 				} else {
 					matching.get().forEach(rep::put);

--- a/srv/src/main/java/my/bookshop/handlers/CatalogServiceHandler.java
+++ b/srv/src/main/java/my/bookshop/handlers/CatalogServiceHandler.java
@@ -181,7 +181,7 @@ class CatalogServiceHandler implements EventHandler {
 
 	private void discountBooksWithMoreThan111Stock(Books b, boolean premium) {
 		if (b.getStock() != null && b.getStock() > 111) {
-			b.setTitle(String.format("%s -- %s%% discount", b.getTitle(), premium ? 14 : 11));
+			b.setTitle("%s -- %s%% discount".formatted(b.getTitle(), premium ? 14 : 11));
 		}
 	}
 

--- a/srv/src/main/java/my/bookshop/handlers/NotesServiceHandler.java
+++ b/srv/src/main/java/my/bookshop/handlers/NotesServiceHandler.java
@@ -56,7 +56,7 @@ public class NotesServiceHandler implements EventHandler {
 	Result readAddresses(CdsReadEventContext context) {
 		List<? extends Segment> segments = context.getCqn().ref().segments();
 		// via note
-		if(segments.size() == 2 && segments.get(0).id().equals(Notes_.CDS_NAME)) {
+		if(segments.size() == 2 && segments.getFirst().id().equals(Notes_.CDS_NAME)) {
 			Map<String, Object> noteKeys = analyzer.analyze(context.getCqn()).rootKeys();
 			Notes note = context.getService().run(Select.from(NOTES).columns(n -> n.address_businessPartner(), n -> n.address_ID()).matching(noteKeys)).single(Notes.class);
 			CqnSelect addressOfNote = CQL.copy(context.getCqn(), new Modifier() {
@@ -115,7 +115,7 @@ public class NotesServiceHandler implements EventHandler {
 	void readNotes(CdsReadEventContext context) {
 		List<? extends Segment> segments = context.getCqn().ref().segments();
 		// via addresses
-		if(segments.size() == 2 && segments.get(0).id().equals(Addresses_.CDS_NAME)) {
+		if(segments.size() == 2 && segments.getFirst().id().equals(Addresses_.CDS_NAME)) {
 			Map<String, Object> addressKeys = analyzer.analyze(context.getCqn()).rootKeys();
 			CqnSelect notesOfAddress = CQL.copy(context.getCqn(), new Modifier() {
 

--- a/srv/src/main/java/my/bookshop/handlers/SubscriptionHandler.java
+++ b/srv/src/main/java/my/bookshop/handlers/SubscriptionHandler.java
@@ -24,7 +24,7 @@ class SubscriptionHandler implements EventHandler {
 
 	@After
 	public void afterSubscribe(SubscribeEventContext context) {
-		String msg = String.format("New tenant '%s' subscribed.", context.getTenant());
+		String msg = "New tenant '%s' subscribed.".formatted(context.getTenant());
 
 		// send audit log security message to provider tenant as user's tenant is null
 		auditLog.logSecurityEvent("tenant subscribed", msg);

--- a/srv/src/test/java/my/bookshop/AdminServiceAddressITestBase.java
+++ b/srv/src/test/java/my/bookshop/AdminServiceAddressITestBase.java
@@ -50,14 +50,14 @@ public class AdminServiceAddressITestBase {
 		order.setShippingAddressId("100");
 
 		String id = UUID.randomUUID().toString();
-		client.put().uri(String.format(orderURI, id))
+		client.put().uri(orderURI.formatted(id))
 				.headers(this::adminCredentials)
 				.header("Content-Type", "application/json")
 				.bodyValue(order.toJson())
 				.exchange()
 				.expectStatus().isCreated();
 
-		client.get().uri(String.format(orderURI, id) + "?$expand=shippingAddress").headers(this::adminCredentials).exchange()
+		client.get().uri(orderURI.formatted(id) + "?$expand=shippingAddress").headers(this::adminCredentials).exchange()
 				.expectStatus().isOk()
 				.expectBody()
 				.jsonPath("$.ID").isEqualTo(id)
@@ -66,7 +66,7 @@ public class AdminServiceAddressITestBase {
 				.jsonPath("$.shippingAddress.businessPartner").isEqualTo("10401010")
 				.jsonPath("$.shippingAddress.houseNumber").isEqualTo("16");
 
-		client.get().uri(String.format(orderURI, id) + "/shippingAddress").headers(this::adminCredentials).exchange()
+		client.get().uri(orderURI.formatted(id) + "/shippingAddress").headers(this::adminCredentials).exchange()
 				.expectStatus().isOk()
 				.expectBody()
 				.jsonPath("$.ID").isEqualTo("100")
@@ -88,7 +88,7 @@ public class AdminServiceAddressITestBase {
 		ABusinessPartnerAddress address = ABusinessPartnerAddress.create();
 		address.setHouseNumber("17");
 
-		client.patch().uri(String.format(remoteAddressURI, "10401010", "100")).headers(this::authenticatedCredentials)
+		client.patch().uri(remoteAddressURI.formatted("10401010", "100")).headers(this::authenticatedCredentials)
 				.header("Content-Type", "application/json")
 				.bodyValue(address.toJson())
 				.exchange()
@@ -96,7 +96,7 @@ public class AdminServiceAddressITestBase {
 
 		// wait for remote address update
 		latch.await(30, TimeUnit.SECONDS);
-		client.get().uri(String.format(orderURI, id) + "/shippingAddress").headers(this::adminCredentials).exchange()
+		client.get().uri(orderURI.formatted(id) + "/shippingAddress").headers(this::adminCredentials).exchange()
 				.expectStatus().isOk()
 				.expectBody()
 				.jsonPath("$.ID").isEqualTo("100")

--- a/srv/src/test/java/my/bookshop/CatalogServiceITest.java
+++ b/srv/src/test/java/my/bookshop/CatalogServiceITest.java
@@ -27,7 +27,7 @@ import cds.gen.catalogservice.Reviews;
 public class CatalogServiceITest {
 
 	private static final String booksURI = "/api/browse/Books";
-	private static final String addReviewURI = String.format("%s(ID=%s)/CatalogService.addReview", booksURI, "f846b0b9-01d4-4f6d-82a4-d79204f62278");
+	private static final String addReviewURI = "%s(ID=%s)/CatalogService.addReview".formatted(booksURI, "f846b0b9-01d4-4f6d-82a4-d79204f62278");
 
 	private static final String USER_USER_STRING = "user";
 	private static final String ADMIN_USER_STRING = "admin";

--- a/srv/src/test/java/my/bookshop/CatalogServiceTest.java
+++ b/srv/src/test/java/my/bookshop/CatalogServiceTest.java
@@ -80,7 +80,7 @@ public class CatalogServiceTest {
 
 		String nonExistingBookId = "non-existing";
 		String exMessage1 = "You have to specify the book to review";
-		String exMessage2 = String.format("A book with the specified ID '%s' does not exist", nonExistingBookId);
+		String exMessage2 = "A book with the specified ID '%s' does not exist".formatted(nonExistingBookId);
 
 		Stream<BookReviewTestFixture> testCases = Stream.of(
 				// no book provided


### PR DESCRIPTION
- Use Java 21 to build sample application
- Use Openrewrite with recipe org.openrewrite.java.migrate.UpgradeToJava21 to demonstrate newer JDK APIs
- Update some outdated build plugins
- Bump enforced min. Maven to 3.6.3 -> required by cds-maven-plugin