### PR TITLE
Hide up__ID in change tracking view

### DIFF
--- a/app/orders/fiori-service.cds
+++ b/app/orders/fiori-service.cds
@@ -291,3 +291,6 @@ annotate AdminService.OrderItems with @(
 //ERROR ALERT: The following line refering to the parents currency code will lead to a server error
 //@Measures.ISOCurrency:parent.currency.code; //Bind the currency field to the quantity field of the parent
 };
+
+
+annotate AdminService.Orders.changes:up_ with @UI.Hidden;

--- a/app/orders/webapp/manifest.json
+++ b/app/orders/webapp/manifest.json
@@ -125,15 +125,6 @@
 										"route": "BooksDetails"
 									}
 								}
-							},
-							"controlConfiguration": {
-								"changes/@com.sap.vocabularies.UI.v1.LineItem": {
-									"columns": {
-										"DataField::up__ID": {
-											"availability": "Hidden"
-										}
-									}
-								}
 							}
 						}
 					}

--- a/app/orders/webapp/manifest.json
+++ b/app/orders/webapp/manifest.json
@@ -125,6 +125,15 @@
 										"route": "BooksDetails"
 									}
 								}
+							},
+							"controlConfiguration": {
+								"changes/@com.sap.vocabularies.UI.v1.LineItem": {
+									"columns": {
+										"DataField::up__ID": {
+											"availability": "Hidden"
+										}
+									}
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Cosmetic change: this change hides the `up__ID` from the change history view. 