### PR TITLE
Don't hardcode `java` build task

### DIFF
--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -212,7 +212,7 @@
 						</goals>
 						<configuration>
 							<commands>
-								<command>build --for java</command>
+								<command>build --production</command>
 								<command>deploy --to h2 --with-mocks --dry &gt;
 									"${project.basedir}/src/main/resources/schema.sql"</command>
 								<command>deploy --to h2 --dry &gt;


### PR DESCRIPTION
In the sample here and in `cds add sample` the `srv/pom.xml` build task is hardcoded to `java`.

It would imo be better to simply use `cds build --production`, as the build itself can determine which plugin to run based on the context.

This hardcoded approach doesn't work with build plugins, for example for the AMS integration. The plugin is automatically pulled for `cds build --production` but left out when the `java` build task is explicitly specified.

@mofterdinger @beckermarc