### PR TITLE
Fix local mtx setup

### DIFF
--- a/db/data/sap.common-Currencies.csv
+++ b/db/data/sap.common-Currencies.csv
@@ -1,4 +1,4 @@
-CODE;SYMBOL;NAME;DESCR
+code;symbol;name;descr
 EUR;€;Euro;European Euro
 USD;$;US Dollar;United States Dollar
 CAD;$;Canadian Dollar;Canadian Dollar

--- a/db/data/sap.common-Currencies.texts.csv
+++ b/db/data/sap.common-Currencies.texts.csv
@@ -1,4 +1,4 @@
-CODE;LOCALE;NAME;DESCR
+code;locale;name;descr
 EUR;de;Euro;European Euro
 USD;de;US-Dollar;United States Dollar
 CAD;de;Kanadischer Dollar;Kanadischer Dollar


### PR DESCRIPTION
This change fixes local mtx setup for the application, so this does not happen after `cds subscribe t1 --to http://localhost:4005 -u yves:`

```
[error] - 500 > {
  code: '500',
  message: 'in cds.deploy(): near "from": syntax error in:\n' +
    "INSERT INTO sap_common_Currencies_texts (CODE,LOCALE,NAME,DESCR) SELECT CASE WHEN OLD.locale IS NULL THEN value->>'$[0]' ELSE (CASE WHEN json_type(value,'$[0]') IS NULL THEN OLD.CODE ELSE value->>'$[0]' END) END as CODE,CASE WHEN OLD.locale IS NULL THEN value->>'$[1]' ELSE (CASE WHEN json_type(value,'$[1]') IS NULL THEN OLD.LOCALE ELSE value->>'$[1]' END) END as LOCALE,CASE WHEN OLD.locale IS NULL THEN value->>'$[2]' ELSE (CASE WHEN json_type(value,'$[2]') IS NULL THEN OLD.NAME ELSE value->>'$[2]' END) END as NAME,CASE WHEN OLD.locale IS NULL THEN value->>'$[3]' ELSE (CASE WHEN json_type(value,'$[3]') IS NULL THEN OLD.DESCR ELSE value->>'$[3]' END) END as DESCR FROM (SELECT value,  from json_each(?)) as NEW LEFT JOIN sap_common_Currencies_texts AS OLD ON NEW.locale=OLD.locale AND NEW.code=OLD.code WHERE TRUE ON CONFLICT(locale,code) DO UPDATE SET CODE = excluded.CODE,LOCALE = excluded.LOCALE,NAME = excluded.NAME,DESCR = excluded.DESCR\n" +
    'Query {\n' +
    '  UPSERT: {\n' +
    "    into: { ref: [ \x1B[32m'sap.common.Currencies.texts'\x1B[39m ] },\n" +
    "    columns: [ \x1B[32m'CODE'\x1B[39m, \x1B[32m'LOCALE'\x1B[39m, \x1B[32m'NAME'\x1B[39m, \x1B[32m'DESCR'\x1B[39m ],\n" +
    '    rows: [\n' +
    "      [ \x1B[32m'EUR'\x1B[39m, \x1B[32m'de'\x1B[39m, \x1B[32m'Euro'\x1B[39m, \x1B[32m'European Euro'\x1B[39m ],\n" +
    "      [ \x1B[32m'USD'\x1B[39m, \x1B[32m'de'\x1B[39m, \x1B[32m'US-Dollar'\x1B[39m, \x1B[32m'United States Dollar'\x1B[39m ],\n" +
    "      [ \x1B[32m'CAD'\x1B[39m, \x1B[32m'de'\x1B[39m, \x1B[32m'Kanadischer Dollar'\x1B[39m, \x1B[32m'Kanadischer Dollar'\x1B[39m ],\n" +
    "      [ \x1B[32m'AUD'\x1B[39m, \x1B[32m'de'\x1B[39m, \x1B[32m'Australischer Dollar'\x1B[39m, \x1B[32m'Australischer Dollar'\x1B[39m ],\n" +
    "      [ \x1B[32m'GBP'\x1B[39m, \x1B[32m'de'\x1B[39m, \x1B[32m'Pfund'\x1B[39m, \x1B[32m'Britische Pfund'\x1B[39m ],\n" +
    "      [ \x1B[32m'ILS'\x1B[39m, \x1B[32m'de'\x1B[39m, \x1B[32m'Schekel'\x1B[39m, \x1B[32m'Israelische Schekel'\x1B[39m ],\n" +
    "      [ \x1B[32m'EUR'\x1B[39m, \x1B[32m'fr'\x1B[39m, \x1B[32m'euro'\x1B[39m, \x1B[32m'de la Zone euro'\x1B[39m ],\n" +
    "      [ \x1B[32m'USD'\x1B[39m, \x1B[32m'fr'\x1B[39m, \x1B[32m'dollar'\x1B[39m, \x1B[32m'dollar des États-Unis'\x1B[39m ],\n" +
    "      [ \x1B[32m'CAD'\x1B[39m, \x1B[32m'fr'\x1B[39m, \x1B[32m'dollar canadien'\x1B[39m, \x1B[32m'dollar canadien'\x1B[39m ],\n" +
    "      [ \x1B[32m'AUD'\x1B[39m, \x1B[32m'fr'\x1B[39m, \x1B[32m'dollar australien'\x1B[39m, \x1B[32m'dollar australien'\x1B[39m ],\n" +
    "      [ \x1B[32m'GBP'\x1B[39m, \x1B[32m'fr'\x1B[39m, \x1B[32m'livre sterling'\x1B[39m, \x1B[32m'pound sterling'\x1B[39m ],\n" +
    "      [ \x1B[32m'ILS'\x1B[39m, \x1B[32m'fr'\x1B[39m, \x1B[32m'Shekel'\x1B[39m, \x1B[32m'shekel israelien'\x1B[39m ]\n" +
    '    ]\n' +
    '  }\n' +
    '}'
}
```

Apparently, the new SQLite driver is much more sensitive to column names. 