### PR TITLE
Remove open endpoint /actuator/health

### DIFF
--- a/srv/src/main/java/my/bookshop/config/WebSecurityConfig.java
+++ b/srv/src/main/java/my/bookshop/config/WebSecurityConfig.java
@@ -18,7 +18,7 @@ public class WebSecurityConfig {
 
 	@Bean
 	public SecurityFilterChain configure(HttpSecurity http) throws Exception {
-		return http.securityMatchers(s -> s.requestMatchers(antMatcher("/actuator/health"), antMatcher("/swagger/**"))) //
+		return http.securityMatchers(s -> s.requestMatchers(antMatcher("/swagger/**"))) //
 				.csrf(c -> c.disable()).authorizeHttpRequests(a -> a.anyRequest().permitAll())
 				.build();
 	}


### PR DESCRIPTION
By default, CAP Java provides the open endpoints `actuator/health/liveness` and `actuator/health/readiness`. Both can be used by Cf or K8s for application health checks.
There is no need for a public `actuator/health` anymore.

See also in mta.yaml: https://github.com/SAP-samples/cloud-cap-samples-java/blob/228e05f940b4d22acc7d88c862fcb6e8c085ff40/mta-multi-tenant.yaml#L18