### PR TITLE
Added missing label to UI annotation

### DIFF
--- a/app/admin/fiori-service.cds
+++ b/app/admin/fiori-service.cds
@@ -29,6 +29,7 @@ annotate AdminService.Books with @(UI : {
         {
             $Type  : 'UI.ReferenceFacet',
             ID     : 'AttachmentsFacet',
+            Label : '{i18n>attachments}',
             Target : 'covers/@UI.LineItem'
         },
         {

--- a/app/admin/fiori-service.cds
+++ b/app/admin/fiori-service.cds
@@ -29,7 +29,7 @@ annotate AdminService.Books with @(UI : {
         {
             $Type  : 'UI.ReferenceFacet',
             ID     : 'AttachmentsFacet',
-            Label : '{i18n>attachments}',
+            Label  : '{i18n>attachments}',
             Target : 'covers/@UI.LineItem'
         },
         {


### PR DESCRIPTION
Current UI:

<img width="1272" alt="image" src="https://github.com/user-attachments/assets/5efa536d-8278-4f01-9e13-852b5c242c45" />

With this fix:

<img width="772" alt="image" src="https://github.com/user-attachments/assets/8137f955-4051-4506-86f6-b2ace55d7333" />
