### PR TITLE
Update cds-feature-attachments and re-use i18n

### DIFF
--- a/app/_i18n/i18n.properties
+++ b/app/_i18n/i18n.properties
@@ -69,11 +69,3 @@ AddReview = Add Review
 Notes = Notes
 Note = Note
 ISBN = ISBN
-
-attachment_content = Content
-attachment_mimeType = MIME Type
-attachment_fileName = File Name
-attachment_status = Status
-attachment_note = Note
-attachment = Cover
-attachments = Covers

--- a/app/_i18n/i18n_de.properties
+++ b/app/_i18n/i18n_de.properties
@@ -69,11 +69,3 @@ AddReview = Rezension hinzufügen
 Notes = Notizen
 Note = Notiz
 ISBN = ISBN
-
-attachment_content = Inhalt
-attachment_mimeType = MIME-Typ
-attachment_fileName = Dateiname
-attachment_status = Status
-attachment_note = Notiz
-attachment = Buchcover
-attachments = Buchcovers

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<cloud.sdk.version>5.15.0</cloud.sdk.version>
 		<xsuaa.version>3.5.7</xsuaa.version>
 		<cf-java-logging-support.version>3.8.4</cf-java-logging-support.version>
-		<cds-feature-attachments.version>1.0.6-SNAPSHOT</cds-feature-attachments.version>
+		<cds-feature-attachments.version>1.0.6</cds-feature-attachments.version>
 	</properties>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<cloud.sdk.version>5.15.0</cloud.sdk.version>
 		<xsuaa.version>3.5.7</xsuaa.version>
 		<cf-java-logging-support.version>3.8.4</cf-java-logging-support.version>
-		<cds-feature-attachments.version>1.0.5</cds-feature-attachments.version>
+		<cds-feature-attachments.version>1.0.6-SNAPSHOT</cds-feature-attachments.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
With version 1.0.6 of the cds-feature-attachments, default UI texts are provided by the plugin itself.