### PR TITLE
Allow to specify a dedicated version for cds-feature-event-hub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 		<!-- DEPENDENCIES VERSION -->
 		<jdk.version>21</jdk.version>
 		<cds.services.version>3.6.0</cds.services.version>
+		<cds-feature-event-hub.version>3.6.0</cds-feature-event-hub.version>
 		<cloud.sdk.version>5.14.0</cloud.sdk.version>
 		<xsuaa.version>3.5.3</xsuaa.version>
 		<cf-java-logging-support.version>3.8.4</cf-java-logging-support.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<!-- DEPENDENCIES VERSION -->
 		<jdk.version>21</jdk.version>
 		<cds.services.version>3.8.0</cds.services.version>
-		<cds-feature-event-hub.version>3.6.0</cds-feature-event-hub.version>
+		<cds-feature-event-hub.version>${cds.services.version}</cds-feature-event-hub.version>
 		<cloud.sdk.version>5.14.0</cloud.sdk.version>
 		<xsuaa.version>3.5.3</xsuaa.version>
 		<cf-java-logging-support.version>3.8.4</cf-java-logging-support.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
 		<!-- DEPENDENCIES VERSION -->
 		<jdk.version>21</jdk.version>
-		<cds.services.version>3.6.0</cds.services.version>
+		<cds.services.version>3.8.0</cds.services.version>
 		<cds-feature-event-hub.version>3.6.0</cds-feature-event-hub.version>
 		<cloud.sdk.version>5.14.0</cloud.sdk.version>
 		<xsuaa.version>3.5.3</xsuaa.version>

--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -76,6 +76,7 @@
 		<dependency>
 			<groupId>com.sap.cds</groupId>
 			<artifactId>cds-feature-event-hub</artifactId>
+			<version>${cds-feature-event-hub.version}</version> <!-- allow to overwrite the event hub feature to switch to the OSS variant -->
 			<scope>runtime</scope>
 		</dependency>		
 


### PR DESCRIPTION
In order to use the OSS variant of `cds-feature-event-hub` it needs to be possible to specify its version independently from the regular cds version