### PR TITLE
Restore up__ID for covers

### DIFF
--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -234,6 +234,7 @@
 						<configuration>
 							<basePackage>cds.gen</basePackage>
 							<strictSetters>true</strictSetters>
+							<interfacesForAspects>true</interfacesForAspects>
 						</configuration>
 					</execution>
 				</executions>

--- a/srv/src/main/java/my/bookshop/handlers/AdminServiceHandler.java
+++ b/srv/src/main/java/my/bookshop/handlers/AdminServiceHandler.java
@@ -23,6 +23,7 @@ import com.sap.cds.ql.Select;
 import com.sap.cds.ql.Update;
 import com.sap.cds.ql.Upsert;
 import com.sap.cds.ql.cqn.CqnAnalyzer;
+import com.sap.cds.ql.cqn.CqnStructuredTypeRef;
 import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.services.ErrorStatuses;
 import com.sap.cds.services.EventContext;
@@ -43,6 +44,7 @@ import cds.gen.adminservice.AdminService;
 import cds.gen.adminservice.AdminService_;
 import cds.gen.adminservice.Books;
 import cds.gen.adminservice.BooksAddToOrderContext;
+import cds.gen.adminservice.BooksCovers;
 import cds.gen.adminservice.Books_;
 import cds.gen.adminservice.OrderItems;
 import cds.gen.adminservice.OrderItems_;
@@ -291,6 +293,12 @@ class AdminServiceHandler implements EventHandler {
 			}
 		}
 		context.setResult(Arrays.asList(upload));
+	}
+
+	@Before(event = {CqnService.EVENT_CREATE, CqnService.EVENT_UPDATE, DraftService.EVENT_DRAFT_NEW, DraftService.EVENT_DRAFT_PATCH})
+	public void restoreCoversUpId(CqnStructuredTypeRef ref, BooksCovers cover) {
+		// restore up__ID, which is not provided via OData due to containment
+		cover.setUpId((String) analyzer.analyze(ref).rootKeys().get(Books.ID));
 	}
 
 	private Supplier<ServiceException> notFound(String message) {


### PR DESCRIPTION
Fixes https://github.com/SAP-samples/cloud-cap-samples-java/issues/452 

Workaround, that is currently required to restore the up__ID, which is no longer provided through the OData API due to containment.