### PR TITLE
Ignore updates to express 5.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
         - "*"
     ignore:
       - dependency-name: "express"
-        # For Express, ignore all updates for version 5
+        # For Express, ignore all updates for version 5 becaue @sap/cds requires express version 4
         versions: ["5.x"]
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,10 @@ updates:
       all-npm-dependencies:
         patterns: 
         - "*"
+    ignore:
+      - dependency-name: "express"
+        # For Express, ignore all updates for version 5
+        versions: ["5.x"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Taken from this example: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#specifying-the-semantic-versioning-level-to-ignore
