### PR TITLE
Prepare new MTX sidecar defaults for CDS 9

### DIFF
--- a/mtx/sidecar/package.json
+++ b/mtx/sidecar/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "@cap-js/hana": "^1",
-    "@sap/cds": "^8",
-    "@sap/cds-mtxs": "^2",
+    "@cap-js/hana": "^2",
+    "@sap/cds": "^9",
+    "@sap/cds-mtxs": "^3",
     "@sap/xssec": "^4",
     "express": "^4"
   },
@@ -13,10 +13,7 @@
     "node": "^20"
   },
   "cds": {
-    "profiles": ["mtx-sidecar", "java"],
-    "[development]": {
-      "requires": { "auth": "dummy" }
-    }
+    "profiles": ["mtx-sidecar", "java"]
   },
   "scripts": {
     "start": "cds-serve",


### PR DESCRIPTION
– Do not merge until CDS 9 is out –

CDS 9 will allow us to simplify the sidecar configuration a little bit, as `requires.auth = "dummy"` for `development` in Java projects by default.