### PR TITLE
Patch the issue on the object items detail page

### DIFF
--- a/app/orders/webapp/manifest.json
+++ b/app/orders/webapp/manifest.json
@@ -135,6 +135,7 @@
 					"name": "sap.fe.templates.ObjectPage",
 					"options": {
 						"settings" : {
+                            "editableHeaderContent": false,
 							"contextPath": "/Orders/Items"
 						}
 					}


### PR DESCRIPTION
Fiori always tries to path a collection values from which are used in the header. This should not happen for `book` as it is association.

This includes a workaround that makes these fields no longer editable.