### PR TITLE
Remove unused mockmvc

### DIFF
--- a/srv/src/test/java/my/bookshop/AdminServiceTest.java
+++ b/srv/src/test/java/my/bookshop/AdminServiceTest.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
 
@@ -25,7 +24,6 @@ import cds.gen.adminservice.OrderItems;
 import cds.gen.adminservice.Orders;
 
 @SpringBootTest
-@AutoConfigureMockMvc
 public class AdminServiceTest {
 
 	@Autowired


### PR DESCRIPTION
Service level tests don't need `@AutoConfigureMockMvc`.