### PR TITLE
Bump cds.services.version from 4.8.0 to 4.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.13</version>
+    <version>3.5.14</version>
     <relativePath/>
     <!-- lookup parent from repository -->
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <!-- DEPENDENCIES VERSION -->
     <jdk.version>21</jdk.version>
-    <cds.services.version>4.8.0</cds.services.version>
+    <cds.services.version>4.9.0</cds.services.version>
     <cloud.sdk.version>5.27.0</cloud.sdk.version>
     <xsuaa.version>3.6.9</xsuaa.version>
     <cf-java-logging-support.version>4.1.1</cf-java-logging-support.version>


### PR DESCRIPTION
The version bump of the cds-dk and other npm dependencies comes with https://github.com/SAP-samples/cloud-cap-samples-java/pull/646