### PR TITLE
Bookshop PostgreSQL: Use SAP build pack with JDK 25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 21
+        java-version: 25
         distribution: sapmachine
 
     - name: Build with Maven

--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ Prerequisites:
 - Install the [Cloud Foundry Command Line Interface](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html).
 - Get an SAP Business Technology Platform account to deploy the services and applications.
 - Ensure you have an entitlement for _PostgreSQL, hyperscaler option_ with appropriate plan in the same space.
-- Ensure that your CF instances are connected to Internet to download SAPMachine JRE 17 as it is available in `sap_java_buildpack` in online mode only and you run in the landscape where the _PostgreSQL, hyperscaler option_ is available.
 
 Deploy Application:
 - Run `mbt build`

--- a/mta.yaml
+++ b/mta.yaml
@@ -17,7 +17,7 @@ modules:
     properties:
         SPRING_PROFILES_ACTIVE: cloud
         JBP_CONFIG_COMPONENTS: '{jres: ["JavaBuildpack::Jre::SapMachineJRE"]}'
-        JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "21.+" } }'
+        JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "25.+" } }'
         # We do not want cfenv to configure the DataSource for us
         # cfenv uses names of the services, so this variable must be adapted if needed
         # as CFENV_SERVICE_[service-name]_ENABLED

--- a/mta.yaml
+++ b/mta.yaml
@@ -13,16 +13,12 @@ modules:
     parameters:
       memory: 1024M
       disk-quota: 512M
-      buildpack: java_buildpack
+      buildpack: sap_java_buildpack_jakarta
     properties:
-        SPRING_PROFILES_ACTIVE: cloud
-        JBP_CONFIG_COMPONENTS: '{jres: ["JavaBuildpack::Jre::SapMachineJRE"]}'
-        JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "25.+" } }'
-        # We do not want cfenv to configure the DataSource for us
-        # cfenv uses names of the services, so this variable must be adapted if needed
-        # as CFENV_SERVICE_[service-name]_ENABLED
-        # See https://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections.html
-        CFENV_SERVICE_BOOKSHOP-PG-DB_ENABLED: false
+      SPRING_PROFILES_ACTIVE: cloud
+      JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jdk.SAPMachineJDK']"
+      JBP_CONFIG_SAP_MACHINE_JDK: '{ version: 25.+ }'
+      JBP_SKIP_PROVIDED_LIBRARY_COMPONENTS: true
     build-parameters:
       builder: custom
       commands:

--- a/mta.yaml
+++ b/mta.yaml
@@ -18,6 +18,8 @@ modules:
       SPRING_PROFILES_ACTIVE: cloud
       JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jdk.SAPMachineJDK']"
       JBP_CONFIG_SAP_MACHINE_JDK: '{ version: 25.+ }'
+      # Skip provided libraries (e.g. PostgreSQL driver) as they are already included in the Bookshop
+      # See: https://help.sap.com/docs/btp/sap-business-technology-platform/application-provided-library-components?locale=en-US&version=Cloud#jbp_skip_provided_library_components
       JBP_SKIP_PROVIDED_LIBRARY_COMPONENTS: true
     build-parameters:
       builder: custom

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<revision>1.0.0-SNAPSHOT</revision>
 
 		<!-- DEPENDENCIES VERSION -->
-		<jdk.version>21</jdk.version>
+		<jdk.version>25</jdk.version>
 		<cds.services.version>4.3.1</cds.services.version>
 		<spring.boot.version>3.5.6</spring.boot.version>
 		<cf-java-logging-support.version>3.8.5</cf-java-logging-support.version>


### PR DESCRIPTION
Successfully deployed and tested in BTP on GCP.

BLI: https://github.wdf.sap.corp/cds-java/home/issues/1463

Build Pack Settings: https://help.sap.com/docs/btp/sap-business-technology-platform/application-provided-library-components?state=DRAFT&locale=en-US