### PR TITLE
Remove containment configuration from .cdsrc.json

### DIFF
--- a/.cdsrc.json
+++ b/.cdsrc.json
@@ -4,8 +4,5 @@
         "extensibility": true,
         "toggles": true
     },
-    "profile": "with-mtx-sidecar",
-    "odata": {
-        "containment": true
-    }
+    "profile": "with-mtx-sidecar"
 }


### PR DESCRIPTION
Draft Messages are working without this explicit switch in cdsrc.json.