### PR TITLE
Update Dependabot configuration to ignore specific versions for xsuaa and spring-boot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,13 @@ updates:
       all-maven-dependencies:
         patterns: 
         - "*"
+    ignore:
+      - dependency-name: "com.sap.cloud.security:*"
+        versions:
+          - ">=4"
+      - dependency-name: "org.springframework.boot:*"
+        versions:
+          - ">=4"
   - package-ecosystem: "npm"
     directories: 
     - "/"


### PR DESCRIPTION
Should avoid PRs like this: https://github.com/SAP-samples/cloud-cap-samples-java/pull/667

main branch still uses Spring-Boot <4 and xsuaa < 4.