### PR TITLE
Fix Genres (VueJs)

### DIFF
--- a/app/vue/app.js
+++ b/app/vue/app.js
@@ -48,7 +48,7 @@ const bookshop = new Vue({
       bookshop.fetchReviews(v && "?$search=" + v),
 
     async fetchBooks(etc = "") {
-      const { data } = await GET(`/Books?$expand=author,genre,currency${etc}`);
+      const { data } = await GET(`/Books?$expand=author,genre($select=ID,name),currency${etc}`);
       bookshop.books = data.value;
     },
 


### PR DESCRIPTION
It is observed, that the VueJs sends the requests like `GET('/Books?$expand=author,genre,currency${etc}')` that leads to selecting the virtual elements for the hierachies.
Fix it by specifying only required elements: `GET('/Books?$expand=author,genre($select=ID,name),currency${etc}')`