### PR TITLE
Fix bookshop native images tests in outbound test pipeline

### DIFF
--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -169,7 +169,7 @@
         <artifactId>native-maven-plugin</artifactId>
         <configuration>
           <metadataRepository>
-            <version>0.3.14</version>
+            <version>0.3.33</version>
           </metadataRepository>
         </configuration>
       </plugin>


### PR DESCRIPTION
Currently, outbound tests for bookshop native images are failing with error 
```
 The configured GraalVM reachability metadata repository at /home/jenkins/agent/workspace/ices-outbound-tests_nightly_main/bookshop-native-image/srv/target/graalvm-reachability-metadata/7de5023997d2db6ebc9d2d50543cec2be999dfb7 does not contain a 'schemas' directory. Requires GraalVM Reachability Metadata 0.3.33 or newer which packages the required schemas
```

This PR is updating the reachability metadata.